### PR TITLE
add onUpdate callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-alive",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "A fork of react-live that allows retrieving the users edits",
   "main": "lib/index.js",
   "typings": "./react-live.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-live",
+  "name": "react-alive",
   "version": "1.5.3",
-  "description": "A production-focused playground for live editing React code",
+  "description": "A fork of react-live that allows retrieving the users edits",
   "main": "lib/index.js",
   "typings": "./react-live.d.ts",
   "jsnext:main": "dist/react-live.es.js",

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -11,6 +11,7 @@ export const LiveContextTypes = {
 
     onError: PropTypes.func,
     onChange: PropTypes.func,
+    onUpdate: PropTypes.func,
 
     element: PropTypes.oneOfType([
       PropTypes.string,
@@ -39,14 +40,14 @@ class LiveProvider extends Component {
   }
 
   onChange = code => {
-    this.transpile(code, this.props.scope, this.props.noInline)
+    this.transpile(code, this.props.scope, this.props.noInline, this.props.onUpdate)
   }
 
   onError = error => {
     this.setState({ error: error.toString() })
   }
 
-  transpile = (code, scope, noInline = false) => {
+  transpile = (code, scope, noInline = false, callback = () => {}) => {
     // Transpilation arguments
     const input = { code, scope }
     const errorCallback = err => this.setState({ element: undefined, error: err.toString() })
@@ -64,6 +65,7 @@ class LiveProvider extends Component {
           generateElement(input, errorCallback)
         )
       }
+      callback(code);
     } catch (error) {
       this.setState({ ...state, error: error.toString() })
     }
@@ -74,7 +76,8 @@ class LiveProvider extends Component {
       ...this.state,
       code: this.props.code,
       onError: this.onError,
-      onChange: this.onChange
+      onChange: this.onChange,
+      onUpdate: this.onUpdate
     }
   })
 
@@ -101,6 +104,7 @@ class LiveProvider extends Component {
       code,
       mountStylesheet,
       noInline,
+      onUpdate,
       ...rest
     } = this.props
 


### PR DESCRIPTION
This is an alternate implementation of what I asked about in #11. It adds an `onUpdate` prop to the `LiveProvider` HOC. It gets triggered after a successful update of the live preview. If there is an error, it is not triggered. `onUpdate` gets called with a single argument containing the user's edits to the code preview.

In my limited use case with react-live, this is something I immediately realized I needed. It's pretty useful to be able to retrieve the user's entered code.

LMK if you like this idea. If so, I'll go ahead and add it to the readme :smile: 