### PR TITLE
Fix invalid onChange prop type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ It accepts these props for styling:
 |className|PropTypes.string|An additional class that is added to the Content Editable
 |ignoreTabKey|PropTypes.bool|Makes the editor ignore tab key presses so that keyboard users can tab past the editor without getting stuck
 |style|PropTypes.object|Additional styles for the Content Editable
-|onChange|PropTypes.function|Accepts a callback that is called when the user makes changes
+|onChange|PropTypes.func|Accepts a callback that is called when the user makes changes
 
 This component renders a Prism.js editor underneath it and also renders all of Prism’s
 styles inside a `style` tag.

--- a/src/components/Live/LiveEditor.js
+++ b/src/components/Live/LiveEditor.js
@@ -18,7 +18,7 @@ const LiveEditor = (props, { live }) => (
 )
 
 LiveEditor.contextTypes = LiveContextTypes
-LiveEditor.propTypes = { onChange: PropTypes.function }
+LiveEditor.propTypes = { onChange: PropTypes.func }
 
 export default LiveEditor
 


### PR DESCRIPTION
This fixes a warning in dev about an "invalid prop type" - It looks like a small oversight writing `function` rather than `func`.

cc @philpl 