### PR TITLE
Adding `transformCode` prop to `LiveProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ It supports these props, while passing all others through to a `<div />`:
 |scope|PropTypes.object|Accepts custom globals that the `code` can use
 |mountStylesheet|PropTypes.bool|Mounts the stylesheet for the prism editor (Default: `true`)
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`)
+|applyTemplate|PropTypes.func|Can be used to wrap the code that should be rendered, before transpilation.
 
 Apart from these props it attaches the `.react-live` CSS class to its `div`.
 All subsequent components must be rendered inside a provider, since they communicate

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It supports these props, while passing all others through to a `<div />`:
 |scope|PropTypes.object|Accepts custom globals that the `code` can use
 |mountStylesheet|PropTypes.bool|Mounts the stylesheet for the prism editor (Default: `true`)
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`)
-|applyTemplate|PropTypes.func|Can be used to wrap the code that should be rendered, before transpilation.
+|transformCode|PropTypes.func|Accepts and returns the code to be transpiled, affording an opportunity to first transform it.
 
 Apart from these props it attaches the `.react-live` CSS class to its `div`.
 All subsequent components must be rendered inside a provider, since they communicate

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -40,21 +40,20 @@ class LiveProvider extends Component {
   }
 
   onChange = code => {
-    const { scope, noInline, transformCode } = this.props;
-    this.transpile(
-      transformCode ? transformCode(code) : code,
-      scope,
-      noInline
-    )
+    const { scope, transformCode, noInline } = this.props;
+    this.transpile({ code, scope, transformCode, noInline });
   }
 
   onError = error => {
     this.setState({ error: error.toString() })
   }
 
-  transpile = (code, scope, noInline = false) => {
+  transpile = ({ code, scope, transformCode, noInline = false }) => {
     // Transpilation arguments
-    const input = { code, scope }
+    const input = {
+      code: transformCode ? transformCode(code) : code,
+      scope
+    }
     const errorCallback = err => this.setState({ element: undefined, error: err.toString() })
     const renderElement = element => this.setState({ ...state, element })
 
@@ -85,18 +84,19 @@ class LiveProvider extends Component {
   })
 
   componentWillMount() {
-    const { code, scope, noInline } = this.props
+    const { code, scope, transformCode, noInline } = this.props
 
-    this.transpile(code, scope, noInline)
+    this.transpile({ code, scope, transformCode, noInline })
   }
 
-  componentWillReceiveProps({ code, scope, noInline }) {
+  componentWillReceiveProps({ code, scope, noInline, transformCode }) {
     if (
       code !== this.props.code ||
       scope !== this.props.scope ||
-      noInline !== this.props.noInline
+      noInline !== this.props.noInline ||
+      transformCode !== this.props.transformCode
     ) {
-      this.transpile(code, scope, noInline)
+      this.transpile({ code, scope, transformCode, noInline })
     }
   }
 
@@ -107,6 +107,7 @@ class LiveProvider extends Component {
       code,
       mountStylesheet,
       noInline,
+      transformCode,
       ...rest
     } = this.props
 

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -35,11 +35,17 @@ class LiveProvider extends Component {
     code: PropTypes.string,
     scope: PropTypes.object,
     mountStylesheet: PropTypes.bool,
-    noInline: PropTypes.bool
+    noInline: PropTypes.bool,
+    applyTemplate: PropTypes.func
   }
 
   onChange = code => {
-    this.transpile(code, this.props.scope, this.props.noInline)
+    const { scope, noInline, applyTemplate } = this.props;
+    this.transpile(
+      applyTemplate ? applyTemplate(code) : code,
+      scope,
+      noInline
+    )
   }
 
   onError = error => {

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -36,13 +36,13 @@ class LiveProvider extends Component {
     scope: PropTypes.object,
     mountStylesheet: PropTypes.bool,
     noInline: PropTypes.bool,
-    applyTemplate: PropTypes.func
+    transformCode: PropTypes.func
   }
 
   onChange = code => {
-    const { scope, noInline, applyTemplate } = this.props;
+    const { scope, noInline, transformCode } = this.props;
     this.transpile(
-      applyTemplate ? applyTemplate(code) : code,
+      transformCode ? transformCode(code) : code,
       scope,
       noInline
     )

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -40,8 +40,8 @@ class LiveProvider extends Component {
   }
 
   onChange = code => {
-    const { scope, transformCode, noInline } = this.props;
-    this.transpile({ code, scope, transformCode, noInline });
+    const { scope, transformCode, noInline } = this.props
+    this.transpile({ code, scope, transformCode, noInline })
   }
 
   onError = error => {


### PR DESCRIPTION
Optionally provide a function to transform the code input, before it gets transpiled. Invisible to the user.

eg:
```
const serverSafe = (code) => `
  if (typeof document !== 'undefined' && typeof window !== 'undefined') {
    ${code}
  }
`;

<LiveProvider transformCode={serverSafe} />
```