### PR TITLE
a11y fix - Correcting Editor swallowing a tab key press

### DIFF
--- a/react-live.css
+++ b/react-live.css
@@ -23,6 +23,10 @@
   -o-tab-size: 2;
   tab-size: 2;
 }
+.prism-code.tab-guarded:focus{
+     outline: 1px solid #212121;
+     outline: 1px auto -webkit-focus-ring-color;
+ }
 
 .token.comment,
 .token.prolog,

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -66,7 +66,7 @@ class Editor extends Component {
   }
 
   updateContent = plain => {
-    this.setState({ html: prism(plain) })
+    this.setState({ html: prism(plain), tabGuarded: false})
 
     if (this.props.onChange) {
       this.props.onChange(plain)
@@ -148,7 +148,12 @@ class Editor extends Component {
 
     this.selection = selectionRange(this.ref)
 
-    if (
+    if (evt.keyCode === 27 && !this.state.tabGuarded) {// Esc Key
+      this.setState({tabGuarded:true})
+    } else if (
+      evt.keyCode !== 27 && // esc
+      evt.keyCode !== 16 && // shift
+      evt.keyCode !== 9 && // tab
       evt.keyCode !== 37 && // left
       evt.keyCode !== 38 && // up
       evt.keyCode !== 39 && // right
@@ -160,12 +165,6 @@ class Editor extends Component {
       this.updateContent(plain)
     } else {
       this.undoTimestamp = 0
-    }
-
-    if (evt.keyCode === 27 && !this.state.tabGuarded) {// Esc Key
-      this.setState({tabGuarded:true})
-    }else if(evt.keyCode !== 27 && evt.keyCode !== 16 && this.state.tabGuarded && evt.keyCode !== 9){
-      this.setState({tabGuarded:false})
     }
   }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -163,17 +163,17 @@ class Editor extends Component {
     }
 
     if (evt.keyCode === 27 && !this.state.tabGuarded) {// Esc Key
-       this.setState({tabGuarded:true})
-     }else if(evt.keyCode !== 27 && evt.keyCode !== 16 && this.state.tabGuarded && evt.keyCode !== 9){
+      this.setState({tabGuarded:true})
+    }else if(evt.keyCode !== 27 && evt.keyCode !== 16 && this.state.tabGuarded && evt.keyCode !== 9){
       this.setState({tabGuarded:false})
-     }
+    }
   }
 
   onBlur = evt =>{
-     if (this.props.onBlur) {
-       this.props.onBlur(evt)
-     }
-     this.setState({tabGuarded:true});
+    if (this.props.onBlur) {
+      this.props.onBlur(evt)
+    }
+    this.setState({tabGuarded:true})
   }
   onClick = evt => {
     if (this.props.onClick) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -168,12 +168,6 @@ class Editor extends Component {
     }
   }
 
-  onBlur = evt =>{
-    if (this.props.onBlur) {
-      this.props.onBlur(evt)
-    }
-    this.setState({tabGuarded:true})
-  }
   onClick = evt => {
     if (this.props.onClick) {
       this.props.onClick(evt)
@@ -222,7 +216,6 @@ class Editor extends Component {
         onKeyDown={contentEditable && this.onKeyDown}
         onKeyUp={contentEditable && this.onKeyUp}
         onClick={contentEditable && this.onClick}
-        onBlur={contentEditable && this.onBlur}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     )

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -168,14 +168,6 @@ class Editor extends Component {
     }
   }
 
-  onBlur = evt =>{
-    if (this.props.onBlur) {
-      this.props.onBlur(evt)
-    }
-    if(!this.state.tabGuarded){
-      this.setState({tabGuarded:true})
-    }
-  }
   onClick = evt => {
     if (this.props.onClick) {
       this.props.onClick(evt)
@@ -224,7 +216,6 @@ class Editor extends Component {
         onKeyDown={contentEditable && this.onKeyDown}
         onKeyUp={contentEditable && this.onKeyUp}
         onClick={contentEditable && this.onClick}
-        onBlur={contentEditable && this.onBlur}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     )

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -168,6 +168,14 @@ class Editor extends Component {
     }
   }
 
+  onBlur = evt =>{
+    if (this.props.onBlur) {
+      this.props.onBlur(evt)
+    }
+    if(!this.state.tabGuarded){
+      this.setState({tabGuarded:true})
+    }
+  }
   onClick = evt => {
     if (this.props.onClick) {
       this.props.onClick(evt)
@@ -216,6 +224,7 @@ class Editor extends Component {
         onKeyDown={contentEditable && this.onKeyDown}
         onKeyUp={contentEditable && this.onKeyUp}
         onClick={contentEditable && this.onClick}
+        onBlur={contentEditable && this.onBlur}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     )

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -17,7 +17,8 @@ class Editor extends Component {
   undoTimestamp = 0
 
   state = {
-    html: ''
+    html: '',
+    tabGuarded: true
   }
 
   onRef = node => {
@@ -102,7 +103,7 @@ class Editor extends Component {
     if (this.props.onKeyDown) {
       this.props.onKeyDown(evt)
     }
-    if (evt.keyCode === 9 && !this.props.ignoreTabKey) { // Tab Key
+    if (evt.keyCode === 9 && !this.state.tabGuarded) { // Tab Key
       document.execCommand('insertHTML', false, '&#009')
       evt.preventDefault()
     } else if (evt.keyCode === 13) { // Enter Key
@@ -160,14 +161,27 @@ class Editor extends Component {
     } else {
       this.undoTimestamp = 0
     }
+
+    if (evt.keyCode === 27 && !this.state.tabGuarded) {// Esc Key
+       this.setState({tabGuarded:true})
+     }else if(evt.keyCode !== 27 && evt.keyCode !== 16 && this.state.tabGuarded && evt.keyCode !== 9){
+      this.setState({tabGuarded:false})
+     }
   }
 
+  onBlur = evt =>{
+     if (this.props.onBlur) {
+       this.props.onBlur(evt)
+     }
+     this.setState({tabGuarded:true});
+  }
   onClick = evt => {
     if (this.props.onClick) {
       this.props.onClick(evt)
     }
     this.undoTimestamp = 0 // Reset timestamp
     this.selection = selectionRange(this.ref)
+    this.setState({tabGuarded:false})
   }
 
   componentWillMount() {
@@ -203,12 +217,13 @@ class Editor extends Component {
       <pre
         {...rest}
         ref={this.onRef}
-        className={cn('prism-code', className)}
+        className={cn('prism-code', className, this.state.tabGuarded?'tab-guarded':'')}
         style={style}
         contentEditable={contentEditable}
         onKeyDown={contentEditable && this.onKeyDown}
         onKeyUp={contentEditable && this.onKeyUp}
         onClick={contentEditable && this.onClick}
+        onBlur={contentEditable && this.onBlur}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     )

--- a/src/constants/css.js
+++ b/src/constants/css.js
@@ -24,7 +24,11 @@ export default `
   -o-tab-size: 2;
   tab-size: 2;
 }
-
+.prism-code.tab-guarded:focus{
+     outline: 1px solid #212121;
+     outline: 1px auto -webkit-focus-ring-color;
+ }
+    
 .token.comment,
 .token.prolog,
 .token.doctype,


### PR DESCRIPTION
Issue https://github.com/FormidableLabs/react-live/issues/19
PR https://github.com/FormidableLabs/react-live/pull/21
For a history of the change refer to the above issue and closed PR. 

It got a bit noisy with all of my commits over subtle changes in code.

The behavior as it's currently presented is that the user may tab over an editor.
Once the click or begin typing while focused on an editor it no longer allows normal tab focus change behavior until the user hits escape or clicks outside the editor.