### PR TITLE
Disable spellcheck in editor

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -205,6 +205,7 @@ class Editor extends Component {
         ref={this.onRef}
         className={cn('prism-code', className)}
         style={style}
+        spellCheck="false"
         contentEditable={contentEditable}
         onKeyDown={contentEditable && this.onKeyDown}
         onKeyUp={contentEditable && this.onKeyUp}


### PR DESCRIPTION
**what is the change?:**
Add `spellCheck="false"` to the `contenteditable` container of the
editor.

**why make this change?:**
In Firefox and probably other places, words that are flagged by the
browser as misspelled will have a dotted underline. This really stands
out in the editor and is distracting, not relevant for code.

**test plan:**
Manual testing - 

*before*
![screen shot 2017-08-30 at 5 09 39 pm](https://user-images.githubusercontent.com/1114467/29900478-115b3298-8da7-11e7-9086-25aeea36bdfc.png)

*after*
![screen shot 2017-08-30 at 5 12 04 pm](https://user-images.githubusercontent.com/1114467/29900480-15e5a6ea-8da7-11e7-8d91-d74ef8008f17.png)

**issue:**
https://github.com/FormidableLabs/react-live/issues/30