### PR TITLE
[fix] Demo link leading to 403 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import {
 
 ## Demo
 
-[https://react-live-demo.philpl.com/](https://react-live-demo.philpl.com/)
+[https://react-live.philpl.com/](https://react-live.philpl.com/)
 
 ## FAQ
 


### PR DESCRIPTION
**Issue:**
https://react-live-demo.philpl.com/ redirects to https://zeit.co/philpl/react-live-demo/dxdmjnnurj?redirect=1 where we get a 403.

**Solution:**
Updating the link to https://react-live.philpl.com/