### PR TITLE
Remove boolean values from non-boolean attributes for React 16

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -207,9 +207,9 @@ class Editor extends Component {
         style={style}
         spellCheck="false"
         contentEditable={contentEditable}
-        onKeyDown={contentEditable && this.onKeyDown}
-        onKeyUp={contentEditable && this.onKeyUp}
-        onClick={contentEditable && this.onClick}
+        onKeyDown={contentEditable ? this.onKeyDown : undefined}
+        onKeyUp={contentEditable ? this.onKeyUp : undefined}
+        onClick={contentEditable ? this.onClick : undefined}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     )


### PR DESCRIPTION
React 16 warns and ignores boolean values in non-boolean
attributes. React 15 converted these to strings and passed
through. Replacing logical operators with ternary in attributes
removes the warning.

https://github.com/alexkuz/react-json-tree/issues/94
https://facebook.github.io/react/blog/2017/09/08/dom-attributes-in-react-16.html

While using the react-live Editor in a React 16 application, console warned the following for `onKeyUp`, `onKeyDown`, and `onClick`:

```
Warning: Expected `onKeyDown` listener to be a function, instead got a value of `boolean` type.
    in pre (created by Editor)
    in Editor (created by LiveEditor)
    in LiveEditor (created by Styled(LiveEditor))
    in Styled(LiveEditor) (created by MapCode)
    in div (created by LiveProvider)
    in LiveProvider (created by Styled(LiveProvider))
    in Styled(LiveProvider) (created by MapCode)
    in MapCode (created by Home)
    in div (created by styled.div)
    in styled.div (created by Home)
    in div (created by styled.div)
    in styled.div (created by Home)
    in Home (created by RouterContext)
    in div (created by styled.div)
    in styled.div (created by Root)
    in Root (created by RouterContext)
    in RouterContext (created by Router)
    in Router
```

Original issue from: https://github.com/alex3165/react-mapbox-gl/pull/393#issuecomment-332854445