### PR TITLE
Remove ignoreTabKey prop before spreading rest to <pre>

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -197,7 +197,9 @@ class Editor extends Component {
   render() {
     const { contentEditable, className, style, ...rest } = this.props
     const { html } = this.state
+
     delete rest.code
+    delete rest.ignoreTabKey
 
     return (
       <pre


### PR DESCRIPTION
Using the `ignoreTabKey` prop causes a warning to be logged to the console in React 16:

> Warning: React does not recognize the `ignoreTabKey` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `ignoretabkey` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

This is because `LiveEditor` [spreads all props](https://github.com/FormidableLabs/react-live/blob/34290462caa206ffac7accb2afcdb908a4975457/src/components/Live/LiveEditor.js#L8) to `Editor` which [does the same](https://github.com/FormidableLabs/react-live/blob/34290462caa206ffac7accb2afcdb908a4975457/src/components/Editor/index.js#L204) to its child `<pre>` tag.

The simplest fix for this is to explicitly remove that prop from the `rest`. To do this, I just followed the coding convention already in place for `rest.code`.