### PR TITLE
Prevent scope from getting on 'react-live' DOM node

### DIFF
--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -108,6 +108,7 @@ class LiveProvider extends Component {
       mountStylesheet,
       noInline,
       transformCode,
+      scope,
       ...rest
     } = this.props
 


### PR DESCRIPTION
A small fix that prevents `scope` prop from getting on the `div` DOM node. Right now it looks like this:

![image](https://user-images.githubusercontent.com/5036933/36216283-9c4812f0-11ae-11e8-83f4-7a957f069682.png)

I'm not sure if this was intentional or not. If it was, sorry for bothering 😅