### PR TITLE
Correctly enable sideEffects for css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
       "../jest.setup.js"
     ]
   },
-  "sideEffects": false
+  "sideEffects": ["*.css"]
 }


### PR DESCRIPTION
react-live sets currently `sideEffects: false` in `package.json` which is correct for all the js files, but not for the css file(s). css obviously always has sideEffects and for now there is no better solution than specifying this in every package. (see ref)

Ref: https://github.com/webpack-contrib/mini-css-extract-plugin/issues/102
