### PR TITLE
fix xss vulnerability by wrapping render code in iframe rather than div

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dom-iterator": "^1.0.0",
     "prismjs": "^1.6.0",
     "prop-types": "^15.5.8",
+    "react-frame-component": "^4.0.0",
     "unescape": "^0.2.0"
   },
   "devDependencies": {

--- a/src/components/Live/LivePreview.js
+++ b/src/components/Live/LivePreview.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Frame from 'react-frame-component'
 import { LiveContextTypes } from './LiveProvider'
 import cn from '../../utils/cn'
 
@@ -6,12 +7,13 @@ const LivePreview = ({ className, ...rest }, { live: { element }}) => {
   const Element = element;
 
   return (
-    <div
+    <Frame
       {...rest}
       className={cn('react-live-preview', className)}
+      style={{ borderWidth: 0, width: '100%' }}
     >
       {Element && <Element />}
-    </div>
+    </Frame>
   );
 }
 


### PR DESCRIPTION
Allowing users to execute arbitrary code can lead to XSS attacks. We prevent this by executing the render code inside an iframe, this way XSS attacks are prevented due to browsers same origin policy. Note that this is hard to test inside storybook since stories are already being rendered inside an iframe.

Using [react-frame-component](https://github.com/ryanseddon/react-frame-component) seems reasonable. tldr; it uses portals to render inside an iframe. I added some additional styling to match the old implementation.

Let me know if you'd like me to make any adjustments.