### PR TITLE
Add wrapper prop support to LivePreview

### DIFF
--- a/src/components/Live/LivePreview.js
+++ b/src/components/Live/LivePreview.js
@@ -2,16 +2,17 @@ import React from 'react'
 import { LiveContextTypes } from './LiveProvider'
 import cn from '../../utils/cn'
 
-const LivePreview = ({ className, ...rest }, { live: { element }}) => {
+const LivePreview = ({ className, wrapper, ...rest }, { live: { element }}) => {
   const Element = element;
-
+  const Wrapper = wrapper || 'div';
+  
   return (
-    <div
+    <Wrapper
       {...rest}
       className={cn('react-live-preview', className)}
     >
       {Element && <Element />}
-    </div>
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
Lets users provide their own wrapper for the LivePreview. Useful when you want to wrap your preview in something like a styled-component that provides some demo styles.

Will update documentation if you're cool with this change.