### PR TITLE
add render prop to LivePreview and README entry on user generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ The context's shape is as follows:
 Using this HOC allows you to add new components to react-live, or replace the default ones, with a new
 desired behaviour.
 
+## A note on user generated code
+Using this library with user generated code should be done carefully. Allowing users to execute arbitrary code, if not done carefully, can lead to XSS (Cross-site scripting) vulnerabilities.
+
 ## Comparison to [component-playground](https://github.com/FormidableLabs/component-playground)
 
 There are multiple options when it comes to live, editable React component environments. Formidable actually has **two** first class projects to help you out: [`component-playground`](https://github.com/FormidableLabs/component-playground) and [`react-live`](https://github.com/FormidableLabs/react-live). Let's briefly look at the libraries, use cases, and factors that might help in deciding which is right for you.

--- a/src/components/Live/LivePreview.js
+++ b/src/components/Live/LivePreview.js
@@ -1,18 +1,26 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { LiveContextTypes } from './LiveProvider'
 import cn from '../../utils/cn'
 
-const LivePreview = ({ className, ...rest }, { live: { element }}) => {
-  const Element = element;
+class LivePreview extends Component {
+  static defaultProps = {
+    renderElement: Element => Element && <Element />
+  }
 
-  return (
-    <div
-      {...rest}
-      className={cn('react-live-preview', className)}
-    >
-      {Element && <Element />}
-    </div>
-  );
+  render() {
+    const { className, live: element, renderElement, ...rest } = this.props;
+
+    const Element = element;
+
+    return (
+      <div
+        {...rest}
+        className={cn('react-live-preview', className)}
+      >
+        {this.props.renderElement(Element)}
+      </div>
+    );
+  }
 }
 
 LivePreview.contextTypes = LiveContextTypes


### PR DESCRIPTION
@kitten As discussed on #79 it would be nice to constrain what code gets executed by adding `defaultProps` to `LivePreview`.  Also adding a README entry about user generated code is a good idea for those uninitiated to XSS.

