### PR TITLE
use code tag along pre tag

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -249,14 +249,18 @@ class Editor extends Component {
         className={cn('prism-code', className)}
         style={style}
         spellCheck="false"
-        contentEditable={contentEditable}
         onCompositionEnd={contentEditable ? this.onCompositionEnd : undefined}
+        contentEditable={contentEditable}
+        suppressContentEditableWarning={contentEditable}
         onCompositionStart={contentEditable ? this.onCompositionStart : undefined}
         onKeyDown={contentEditable ? this.onKeyDown : undefined}
         onKeyUp={contentEditable ? this.onKeyUp : undefined}
         onClick={contentEditable ? this.onClick : undefined}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      >
+        <code
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </pre>
     )
   }
 }


### PR DESCRIPTION
@kitten This adds a `code` tag to the Editor. Using `<pre><code>` has a few advantages:
* More semantic and accesible code
* A more customizable prism. Using some prism features like Line highlight and Line Numbers (at least from the examples) involve having both a `pre` and a `code` tag.
https://prismjs.com/plugins/line-highlight/
https://prismjs.com/plugins/line-numbers/
both of this say:
>Obviously, this only works on code blocks (`<pre><code>`) and not for inline code.

Functionality also seems to be identical.

w3/html 5 agrees with using `pre` with `code` as well
> To represent a block of computer code, the pre element can be used with a code element; to represent a block of computer output the pre element can be used with a samp element. Similarly, the kbd element can be used within a pre element to indicate text that the user is to enter.

https://www.w3.org/TR/html5/grouping-content.html#the-pre-element

I also had to add a `supressContentEditableWarning` to avoid this error 
> Warning: A component is contentEditable and contains children managed by React. It is now your responsibility to guarantee that none of those nodes are unexpectedly modified or duplicated. This is probably not intentional.

More details about this error in [this `draftjs` issue](https://github.com/facebook/draft-js/issues/81), it seems safe to supress it. If we put the `contentEditable` prop in the `<code>` tag we get something like this:

<img width="581" alt="screen shot 2018-07-22 at 10 20 02 pm" src="https://user-images.githubusercontent.com/4564870/43058649-7b39c394-8dfd-11e8-95a8-66b8a696f15f.png">

which could be fixed with css but it's not ideal.