### PR TITLE
Update typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "rootDir": "./src",
     "setupFiles": [
       "../jest.setup.js"
-    ]
+    ],
+    "testURL": "http://localhost/"
   },
   "sideEffects": false
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify-es": "^0.0.1",
-    "typescript": "^2.7.1",
+    "typescript": "^2.9.2",
     "typings-tester": "^0.3.1"
   },
   "files": [

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -4,7 +4,8 @@ import { ComponentClass, StatelessComponent, HTMLProps } from 'react'
 type Component<P> = ComponentClass<P> | StatelessComponent<P>
 
 // Helper types
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
+type KeyType = string | number | symbol;
+type Diff<T extends KeyType, U extends KeyType> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
 
 // React Element Props


### PR DESCRIPTION
* Updates TypeScript version, and in the process updates the typings to get around a breaking change in newer versions of TypeScript. This is to ensure the library is compatible with projects using newer versions of TypeScript for compilation. See  Microsoft/TypeScript#23592.

* Adds a workaround for jest tests failing facebook/jest#6766