### PR TITLE
Pin buble version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:typings": "typings-tester --dir typings"
   },
   "dependencies": {
-    "buble": "^0.19.3",
+    "buble": "0.19.4",
     "core-js": "^2.4.1",
     "create-react-context": "^0.2.3",
     "dom-iterator": "^1.0.0",


### PR DESCRIPTION
Buble 0.19.5 introduces an error that causes react-live to fail.  This PR pins the version until that issue is remedied.