### PR TITLE
Use Fragments to render several components once

### DIFF
--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -32,6 +32,9 @@ export default class LiveProvider extends Component {
   };
 
   transpile = ({ code, scope, transformCode, noInline = false }) => {
+    if(!noInline){
+      code = `<>${code}</>`
+    }
     // Transpilation arguments
     const input = {
       code: transformCode ? transformCode(code) : code,


### PR DESCRIPTION
This makes it possible to simply render as many components at once, without having to make a wrapper.

## Example
```jsx
<LiveProvider code={`
<div className="one" />
<div className="two" />
`}>
...
</LiveProvider>
```