### PR TITLE
Use pre for error to preserve whitespace

### DIFF
--- a/src/components/Live/LiveError.js
+++ b/src/components/Live/LiveError.js
@@ -7,9 +7,9 @@ export default function LiveError({ className, ...rest }) {
     <LiveContext.Consumer>
       {({ error }) =>
         error ? (
-          <div {...rest} className={cn('react-live-error', className)}>
+          <pre {...rest} className={cn('react-live-error', className)}>
             {error}
-          </div>
+          </pre>
         ) : null
       }
     </LiveContext.Consumer>


### PR DESCRIPTION
Should use `pre` instead of `div` for error to preserve white space

👎 
![screenshot 2019-02-26 at 7 37 57 am](https://user-images.githubusercontent.com/1863771/53382242-aacf4280-3999-11e9-9e5b-671c2ecef09d.png)

👍 
![screenshot 2019-02-26 at 7 38 02 am](https://user-images.githubusercontent.com/1863771/53382239-a99e1580-3999-11e9-9eb1-3b9a7fa4cdd8.png)

---

Note: There is a simple workaround to this

```css
.react-live-error {
  white-space: pre;
}
```