### PR TITLE
Upgrade Prism.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "core-js": "^2.4.1",
     "create-react-context": "^0.2.3",
     "dom-iterator": "^1.0.0",
-    "prismjs": "1.6",
+    "prismjs": "^1.15.0",
     "prop-types": "^15.5.8",
     "unescape": "^0.2.0"
   },


### PR DESCRIPTION
Prism is way behind, and many syntax highlighting bugs have been fixed since 1.6.0.