### PR TITLE
fix: removed unused className on LiveProvider

### DIFF
--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -13,7 +13,6 @@ export default class LiveProvider extends Component {
   };
 
   static propTypes = {
-    className: PropTypes.string,
     code: PropTypes.string,
     language: PropTypes.string,
     disabled: PropTypes.bool,


### PR DESCRIPTION
noticed here: https://github.com/react-bootstrap/react-bootstrap/pull/3631

Since this commit: https://github.com/FormidableLabs/react-live/commit/a7f0cf144897392abbcbfd35026c769649c53811#diff-c4542d3ce4efdafdf35660d1c7f57a33L105 LiveProvider is not anymore a `div`. So styling is not possible anymore. As a workaround the children can be wrapped into a `div` with styles e.g. Styled Components.