### PR TITLE
Update LiveProviderProps type

### DIFF
--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, StatelessComponent, HTMLProps, ComponentType } from 'react'
+import { ComponentClass, StatelessComponent, HTMLProps, ComponentType, CSSProperties } from 'react'
 
 // Helper types
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
@@ -13,6 +13,12 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   code?: string;
   noInline?: boolean;
   transformCode?: (code: string) => string;
+  language?: string;
+  disabled?: boolean;
+  theme?: {
+    plain: CSSProperties;
+    styles: Array<{ types: string[]; styles: CSSProperties }>;
+  }
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,4 +1,5 @@
-import { ComponentClass, StatelessComponent, HTMLProps, ComponentType, CSSProperties } from 'react'
+import { ComponentClass, StatelessComponent, HTMLProps, ComponentType } from 'react'
+import { PrismTheme, Language } from 'prism-react-renderer';
 
 // Helper types
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
@@ -13,12 +14,9 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   code?: string;
   noInline?: boolean;
   transformCode?: (code: string) => string;
-  language?: string;
+  language?: Language;
   disabled?: boolean;
-  theme?: {
-    plain: CSSProperties;
-    styles: Array<{ types: string[]; styles: CSSProperties }>;
-  }
+  theme?: PrismTheme;
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -15,6 +15,14 @@ export const providerC = (
     scope={{ Component: React.Component }}
     transformCode={(code: string): string => code + ';;'}
     noInline={false}
+    language="typescript"
+    theme={{
+      plain: {
+        fontWeight: '800',
+        color: 'salmon'
+      },
+      styles: []
+    }}
   />
 );
 


### PR DESCRIPTION
I've updated `type LiveProviderProps` to match the table in README.md and PropTypes.

https://github.com/FormidableLabs/react-live/blob/master/src/components/Live/LiveProvider.js#L15
https://github.com/FormidableLabs/react-live#liveprovider-
https://github.com/FormidableLabs/prism-react-renderer#theming