### PR TITLE
Remove redundant types

### DIFF
--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,12 +1,7 @@
-import { ComponentClass, StatelessComponent, HTMLProps } from 'react'
-
-// React union type
-type Component<P> = ComponentClass<P> | StatelessComponent<P>
+import { ComponentClass, StatelessComponent, HTMLProps, ComponentType } from 'react'
 
 // Helper types
-type KeyType = string | number | symbol;
-type Diff<T extends KeyType, U extends KeyType> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 // React Element Props
 type DivProps = HTMLProps<HTMLDivElement>
@@ -43,4 +38,4 @@ export const LiveError: ComponentClass<DivProps>
 export const LivePreview: ComponentClass<DivProps>
 
 // withLive HOC
-export function withLive<P>(wrappedComponent: Component<P>): ComponentClass<P>
+export function withLive<P>(wrappedComponent: ComponentType<P>): ComponentClass<P>


### PR DESCRIPTION
We can get rid of `Component` in favor of `ComponentType` defined in `@types/react`.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L74

TypeScript 2.8 adds Exclude
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types