### PR TITLE
TypeScript typings: expose `theme` prop

### DIFF
--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -7,12 +7,15 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type DivProps = HTMLProps<HTMLDivElement>
 type PreProps = HTMLProps<HTMLPreElement>
 
+type Theme = any
+
 // LiveProvider
 export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
   transformCode?: (code: string) => string;
+  theme?: Theme;
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>
@@ -26,7 +29,8 @@ export const Editor: ComponentClass<EditorProps>
 
 // LiveEditor
 export type LiveEditorProps = Omit<EditorProps, 'onChange'> & {
-  onChange?: (code: string) => void
+  onChange?: (code: string) => void;
+  theme?: Theme;
 }
 
 export const LiveEditor: ComponentClass<LiveEditorProps>


### PR DESCRIPTION
I am currently working around with `// @ts-ignore` but would be nicer to specify the `theme` without that.

Added `type Theme = any`, not sure exactly what the type should be.