### PR TITLE
Handle optional `theme.plain` object, add storybook example #139

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -55,8 +55,20 @@ class CodeEditor extends Component {
   );
 
   render() {
-    const { style, code: _code, onChange, language, ...rest } = this.props;
+    const {
+      style,
+      code: _code,
+      onChange,
+      language,
+      theme,
+      ...rest
+    } = this.props;
     const { code } = this.state;
+
+    // const baseTheme = theme || liveTheme;
+    console.log(theme, 'theme!');
+    const baseTheme =
+      theme && typeof theme.plain === 'object' ? theme.plain : {};
 
     return (
       <Editor
@@ -67,6 +79,7 @@ class CodeEditor extends Component {
         style={{
           whiteSpace: 'pre',
           fontFamily: 'monospace',
+          ...baseTheme,
           ...style
         }}
         {...rest}

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -65,8 +65,6 @@ class CodeEditor extends Component {
     } = this.props;
     const { code } = this.state;
 
-    // const baseTheme = theme || liveTheme;
-    console.log(theme, 'theme!');
     const baseTheme =
       theme && typeof theme.plain === 'object' ? theme.plain : {};
 

--- a/stories/Live.js
+++ b/stories/Live.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean } from '@storybook/addon-knobs/react';
+import { theme } from '../src/constants/theme';
 
 import {
   LiveProvider,
@@ -76,7 +77,7 @@ const StyledLivePreview = styled(LivePreview)`
 `;
 
 const StyledEditor = styled(LiveEditor)`
-  background: #322e3c;
+  background: #46424f;
 `;
 
 const StyledTextarea = styled.textarea`
@@ -159,6 +160,19 @@ storiesOf('Live', module)
       disabled={boolean('Disable editing', false)}
       language="jsx"
       noInline={boolean('No inline evaluation', false)}
+    >
+      <StyledEditor />
+      <LiveError />
+      <LivePreview />
+    </LiveProvider>
+  ))
+  .add('component with theme', () => (
+    <LiveProvider
+      code={componentExample}
+      disabled={boolean('Disable editing', false)}
+      language="jsx"
+      noInline={boolean('No inline evaluation', false)}
+      theme={theme}
     >
       <StyledEditor />
       <LiveError />


### PR DESCRIPTION
Fix for issue #139. 

Will remove the commented out line on `68` of `Editor/index.js` before removing `WIP` status.

I thought it could make the most sense to pass in everything from `theme.plain` as the element-level style, meaning that - if no `theme` prop is used, we don't add anything, rather than defaulting to a base theme, as people might not expect this/it might get frustrating for people just using styled components.