### PR TITLE
Fix `theme is not defined` ReferenceError by passing theme prop

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -59,7 +59,14 @@ class CodeEditor extends Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { style, code: _code, onChange, language, ...rest } = this.props;
+    const {
+      style,
+      code: _code,
+      onChange,
+      language,
+      theme,
+      ...rest
+    } = this.props;
     const { code } = this.state;
 
     const baseTheme =


### PR DESCRIPTION
Fixes `theme is not defined` error in latest release