### PR TITLE
Update the version of create-react-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "buble": "0.19.6",
     "core-js": "^2.4.1",
-    "create-react-context": "^0.2.3",
+    "create-react-context": "^0.2.2",
     "dom-iterator": "^1.0.0",
     "prism-react-renderer": "^0.1.0",
     "prop-types": "^15.5.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "buble": "0.19.6",
     "core-js": "^2.4.1",
-    "create-react-context": "^0.2.2",
+    "create-react-context": "0.2.2",
     "dom-iterator": "^1.0.0",
     "prism-react-renderer": "^0.1.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
Version 0.2.3 of `create-react-context` does not have an MIT license. As a result, many companies are unable to use `react-live`. Between v0.2.2 and v0.2.3 only the license and the README has changed, it is safe to depend on `v0.2.2` rather than `v0.2.3`.