### PR TITLE
Removes prism-react-renderer from the bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,13 +46,13 @@ const prodPlugins = plugins.concat([
 
 const base = {
   input: 'src/index.js',
-  external: ['react', 'react-dom', 'prismjs', 'buble']
+  external: ['react', 'react-dom', 'prism-react-renderer', 'buble']
 };
 
 const output = {
   exports: 'named',
   globals: {
-    prismjs: 'Prism',
+    'prism-react-renderer': 'Prism',
     react: 'React',
     buble: 'Buble',
     'react-dom': 'ReactDOM'


### PR DESCRIPTION
This PR fixes prism-react-renderer from being included in the dist. 

1. Rename references to prismjs -> prism-react-renderer.

Reduces bundled code size to 7.26 KB.