### PR TITLE
Safely catch calls with empty render. Fixes #151

### DIFF
--- a/src/utils/test/transpile.test.js
+++ b/src/utils/test/transpile.test.js
@@ -72,6 +72,29 @@ describe('transpile', () => {
       );
     });
 
+    it('should emit error if render is not called with valid JSX', () => {
+      const errorCb = jest.fn();
+
+      renderElementAsync({ code: 'render()' }, null, errorCb);
+      expect(errorCb).toHaveBeenCalledWith(
+        new SyntaxError('`render` must be called with valid JSX.')
+      );
+    });
+
+    it('should emit result if render is called with a falsey value', () => {
+      const resultCb = jest.fn();
+      const code = 'render(null)';
+
+      renderElementAsync({ code }, resultCb);
+
+      expect(resultCb).toHaveBeenCalled();
+
+      const Component = resultCb.mock.calls[0][0];
+      const wrapper = shallow(<Component />);
+
+      expect(wrapper.html()).toBe(null);
+    })
+
     it('should emit result via the result callback', () => {
       const resultCb = jest.fn();
       const code = 'render(<div>Hello World!</div>)';

--- a/src/utils/test/transpile.test.js
+++ b/src/utils/test/transpile.test.js
@@ -93,7 +93,7 @@ describe('transpile', () => {
       const wrapper = shallow(<Component />);
 
       expect(wrapper.html()).toBe(null);
-    })
+    });
 
     it('should emit result via the result callback', () => {
       const resultCb = jest.fn();

--- a/src/utils/transpile/index.js
+++ b/src/utils/transpile/index.js
@@ -19,7 +19,11 @@ export const renderElementAsync = (
   // eslint-disable-next-line consistent-return
 ) => {
   const render = element => {
-    resultCallback(errorBoundary(element, errorCallback));
+    if (typeof element === "undefined") {
+      errorCallback(new SyntaxError('`render` must be called with valid JSX.'));
+    } else {
+      resultCallback(errorBoundary(element, errorCallback));
+    }
   };
 
   if (!/render\s*\(/.test(code)) {


### PR DESCRIPTION
Prevents the application from breaking if `render` is called while `noInline` is true (see: https://github.com/FormidableLabs/react-live/issues/151)

Example (after changes):
![error](https://user-images.githubusercontent.com/1939140/60689980-43aa2900-9e78-11e9-8bb5-d0df2db3ef2a.PNG)
