### PR TITLE
Fix: Update demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import {
 
 ## Demo
 
-[https://react-live.kitten.sh/](https://react-live.kitten.sh/)
+[https://react-live.netlify.com/](https://react-live.netlify.com/)
 
 ## FAQ
 


### PR DESCRIPTION
The old link (https://react-live.kitten.sh/) seems broken and https://react-live.netlify.com/ is already present in the repository description header.