### PR TITLE
Add `onError` prop to LiveProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ It supports these props, while passing any others through to the `children`:
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`). Note: when using `noInline` whatever code you write must be a single expression (function, class component or some `jsx`) that can be returned immediately. If you'd like to render multiple components, use `noInline={true}`
 |transformCode|PropTypes.func|Accepts and returns the code to be transpiled, affording an opportunity to first transform it
 |onError|PropTypes.func|Called with `Error` object when render fails. Allows you to listen for errors and implement custom logic.|
+|onRender|PropTypes.func|Called when component is rendered successfully. Can be used alongside `onError` to clear own error state.|
 |language|PropTypes.string|What language you're writing for correct syntax highlighting. (Default: `jsx`)
 |disabled|PropTypes.bool|Disable editing on the `<LiveEditor />` (Default: `false`)
 |theme|PropTypes.object|A `prism-react-renderer` theme object. See more [here](https://github.com/FormidableLabs/prism-react-renderer#theming)
@@ -244,5 +245,5 @@ Here are the various factors at play:
 
 ## Maintenance Status
 
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ It supports these props, while passing any others through to the `children`:
 |scope|PropTypes.object|Accepts custom globals that the `code` can use
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`). Note: when using `noInline` whatever code you write must be a single expression (function, class component or some `jsx`) that can be returned immediately. If you'd like to render multiple components, use `noInline={true}`
 |transformCode|PropTypes.func|Accepts and returns the code to be transpiled, affording an opportunity to first transform it
-|onError|PropTypes.func|Called with `Error` object when render fails. Allows you to listen for errors and implement custom logic.|
-|onRender|PropTypes.func|Called when component is rendered successfully. Can be used alongside `onError` to clear own error state.|
+|onRender|PropTypes.func|Called when component is rendered (un)successfully. In the case of an unsuccessful render, an `Error` object is passed as the only argument.|
 |language|PropTypes.string|What language you're writing for correct syntax highlighting. (Default: `jsx`)
 |disabled|PropTypes.bool|Disable editing on the `<LiveEditor />` (Default: `false`)
 |theme|PropTypes.object|A `prism-react-renderer` theme object. See more [here](https://github.com/FormidableLabs/prism-react-renderer#theming)

--- a/README.md
+++ b/README.md
@@ -244,5 +244,5 @@ Here are the various factors at play:
 
 ## Maintenance Status
 
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ It supports these props, while passing any others through to the `children`:
 |scope|PropTypes.object|Accepts custom globals that the `code` can use
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`). Note: when using `noInline` whatever code you write must be a single expression (function, class component or some `jsx`) that can be returned immediately. If you'd like to render multiple components, use `noInline={true}`
 |transformCode|PropTypes.func|Accepts and returns the code to be transpiled, affording an opportunity to first transform it
+|onError|PropTypes.func|Called with `Error` object when render fails. Allows you to listen for errors and implement custom logic.|
 |language|PropTypes.string|What language you're writing for correct syntax highlighting. (Default: `jsx`)
 |disabled|PropTypes.bool|Disable editing on the `<LiveEditor />` (Default: `false`)
 |theme|PropTypes.object|A `prism-react-renderer` theme object. See more [here](https://github.com/FormidableLabs/prism-react-renderer#theming)
@@ -243,5 +244,5 @@ Here are the various factors at play:
 
 ## Maintenance Status
 
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -93,6 +93,9 @@ export default class LiveProvider extends Component {
       }
     } catch (error) {
       this.setState({ ...state, error: error.toString() });
+      if (this.props.onError) {
+        this.props.onError();
+      }
     }
   };
 

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -18,6 +18,8 @@ export default class LiveProvider extends Component {
     disabled: PropTypes.bool,
     language: PropTypes.string,
     noInline: PropTypes.bool,
+    onError: PropTypes.func,
+    onRender: PropTypes.func,
     scope: PropTypes.object,
     theme: PropTypes.object,
     transformCode: PropTypes.node
@@ -54,7 +56,9 @@ export default class LiveProvider extends Component {
 
   onError = error => {
     this.setState({ error: error.toString() });
-    this.props.onError && this.props.onError(error);
+    if (this.props.onError) {
+      this.props.onError(error);
+    }
   };
 
   transpile = ({ code, scope, transformCode, noInline = false }) => {
@@ -66,9 +70,16 @@ export default class LiveProvider extends Component {
 
     const errorCallback = err => {
       this.setState({ element: undefined, error: err.toString() });
-      this.props.onError && this.props.onError(error);
+      if (this.props.onError) {
+        this.props.onError(err);
+      }
     };
-    const renderElement = element => this.setState({ ...state, element });
+    const renderElement = element => {
+      this.setState({ ...state, element });
+      if (this.props.onRender) {
+        this.props.onRender();
+      }
+    };
 
     // State reset object
     const state = { unsafeWrapperError: undefined, error: undefined };

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -18,7 +18,6 @@ export default class LiveProvider extends Component {
     disabled: PropTypes.bool,
     language: PropTypes.string,
     noInline: PropTypes.bool,
-    onError: PropTypes.func,
     onRender: PropTypes.func,
     scope: PropTypes.object,
     theme: PropTypes.object,
@@ -56,8 +55,8 @@ export default class LiveProvider extends Component {
 
   onError = error => {
     this.setState({ error: error.toString() });
-    if (this.props.onError) {
-      this.props.onError(error);
+    if (this.props.onRender) {
+      this.props.onRender(error);
     }
   };
 
@@ -70,8 +69,8 @@ export default class LiveProvider extends Component {
 
     const errorCallback = err => {
       this.setState({ element: undefined, error: err.toString() });
-      if (this.props.onError) {
-        this.props.onError(err);
+      if (this.props.onRender) {
+        this.props.onRender(err);
       }
     };
     const renderElement = element => {
@@ -93,8 +92,8 @@ export default class LiveProvider extends Component {
       }
     } catch (error) {
       this.setState({ ...state, error: error.toString() });
-      if (this.props.onError) {
-        this.props.onError();
+      if (this.props.onRender) {
+        this.props.onRender();
       }
     }
   };

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -93,7 +93,7 @@ export default class LiveProvider extends Component {
     } catch (error) {
       this.setState({ ...state, error: error.toString() });
       if (this.props.onRender) {
-        this.props.onRender();
+        this.props.onRender(error);
       }
     }
   };

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -54,6 +54,7 @@ export default class LiveProvider extends Component {
 
   onError = error => {
     this.setState({ error: error.toString() });
+    this.props.onError && this.props.onError(error);
   };
 
   transpile = ({ code, scope, transformCode, noInline = false }) => {
@@ -63,8 +64,10 @@ export default class LiveProvider extends Component {
       scope
     };
 
-    const errorCallback = err =>
+    const errorCallback = err => {
       this.setState({ element: undefined, error: err.toString() });
+      this.props.onError && this.props.onError(error);
+    };
     const renderElement = element => this.setState({ ...state, element });
 
     // State reset object

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -17,7 +17,8 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void;
+  onRender?: () => void;
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -17,6 +17,7 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
+  onError?: (error: Error) => void
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -9,7 +9,7 @@ type DivProps = HTMLProps<HTMLDivElement>
 type PreProps = HTMLProps<HTMLPreElement>
 
 // LiveProvider
-export type LiveProviderProps = Omit<DivProps, 'scope' | 'onError'> & {
+export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
@@ -17,8 +17,7 @@ export type LiveProviderProps = Omit<DivProps, 'scope' | 'onError'> & {
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
-  onError?: (error: Error) => void;
-  onRender?: () => void;
+  onRender?: (error?: Error) => void;
 }
 
 export const LiveProvider: ComponentClass<LiveProviderProps>

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -9,7 +9,7 @@ type DivProps = HTMLProps<HTMLDivElement>
 type PreProps = HTMLProps<HTMLPreElement>
 
 // LiveProvider
-export type LiveProviderProps = Omit<DivProps, 'scope'> & {
+export type LiveProviderProps = Omit<DivProps, 'scope' | 'onError'> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;


### PR DESCRIPTION
I need a way to get the `Error` object instead of just rendering it through `<LiveError />`. I couldn't find a way to do this so I thought I'd add simple `onError` + `onRender` props to `LiveProvider`. Devs can then set these handlers if they want to do some custom error handling.

Please let me know if I missed anything or if you don't feel this is a good addition.