### PR TITLE
Update `react-simple-code-editor`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dom-iterator": "^1.0.0",
     "prism-react-renderer": "^0.1.0",
     "prop-types": "^15.5.8",
-    "react-simple-code-editor": "^0.9.0",
+    "react-simple-code-editor": "^0.10.0",
     "unescape": "^0.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7961,10 +7961,10 @@ react-onclickoutside@^6.5.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz#9f91b5b3ed59f4d9e43fd71620dc200773a4d569"
   integrity sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA==
 
-react-simple-code-editor@^0.9.0:
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.14.tgz#5b8fdc36a975cbf02fdafa2597398d8e212afebc"
-  integrity sha512-doNaIIt4w7QIiB6ysWHMtYL4M3xOGPvZJH8vGq3W/hGk43pn25RDA27IS8GkbfhA1eLX72CWDhuC7KmDKax13g==
+react-simple-code-editor@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
+  integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
 react-split-pane@^0.1.77:
   version "0.1.87"


### PR DESCRIPTION
This is to absorb [this PR](https://github.com/satya164/react-simple-code-editor/pull/43) on `react-simple-code-editor` that solves the keyboard trap issue. You can read more on the issue page.

Fixes [chakra-ui #5](https://github.com/chakra-ui/chakra-ui/issues/5)
(chakra-ui docs uses `react-live` which uses `react-simple-code-editor`)

/cc @sofiapoh @segunadebayo