### PR TITLE
fix: demo start scripts

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "dev": "node server.js",
-    "build": "next build && next export",
-    "start": "NODE_ENV=production node server.js"
+    "prebuild": "cd .. && yarn && yarn build",
+    "prebuild:npm": "cd .. && npm i && npm run build",
+    "dev": "next",
+    "build": "next build",
+    "start": "NODE_ENV=production next start"
   },
   "dependencies": {
     "babel-plugin-polished": "^1.0.3",


### PR DESCRIPTION
In demo/package.json，I use next directly.
And I delete next.config.js because running demo doesn't need it.