### PR TITLE
Adds missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "react-simple-code-editor": "^0.10.0",
     "unescape": "^1.0.1"
   },
+  "peerDependencies": {
+    "react-dom": "*",
+    "react": "*"
+  },
   "devDependencies": {
     "@storybook/addon-knobs": "^3.3.12",
     "@storybook/react": "^3.3.12",


### PR DESCRIPTION
Missing peer dependencies cause package managers to incorrectly hoist packages, causing subtle breakages particularly hard to debug.