### PR TITLE
Adds information on escaping focus traps in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ with valid JSX elements.
 This component renders the editor that displays the code. It is a wrapper around [`react-simple-code-editor`](https://github.com/satya164/react-simple-code-editor) and the code highlighted using [`prism-react-renderer`](https://github.com/FormidableLabs/prism-react-renderer).
 
 
+`LiveEditor` can create a focus trap on the page for users using keyboard navigation. `react-simple-code-editor` provides a focus escape hatch via the `escape` key, allowing the user to continue tab navigating. More custom solutions may be passed down via the `onKeyDown` property with an `event.preventDefault` included in the handler. For example if you would like to exit the focus state when pressing the tab key inside the editor:
+
+```js
+<LiveEditor onKeyDown={(e) => {
+   if (e.keyCode === 9 ) { // tab key
+      e.preventDefault()
+      e.target.blur()
+   }
+ }}
+/>
+
+```
+
+
 ### &lt;LiveError /&gt;
 
 This component renders any error that occur while executing the code, or transpiling it.


### PR DESCRIPTION
Addresses issue #179 : existing focus trap handling is built into `react-simple-code-editor`, this PR surfaces that information in the README and provides further suggestions if a user would like to implement a more custom solution