### PR TITLE
Fix EditorProps type

### DIFF
--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -28,6 +28,7 @@ export type EditorProps = Omit<PreProps, 'onChange'> & {
   language?: Language;
   onChange?: (code: string) => void;
   theme?: PrismTheme;
+  padding?: number | string;
 }
 
 export const Editor: ComponentClass<EditorProps>

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,5 +1,6 @@
-import { ComponentClass, StatelessComponent, HTMLProps, ComponentType, Context } from 'react'
+import { ComponentClass, StatelessComponent, HTMLProps, ComponentType, Context, ComponentProps } from 'react'
 import { PrismTheme, Language } from 'prism-react-renderer';
+import CodeEditor from 'react-simple-code-editor';
 
 // Helper types
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
@@ -22,13 +23,12 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
 export const LiveProvider: ComponentClass<LiveProviderProps>
 
 // Editor
-export type EditorProps = Omit<PreProps, 'onChange'> & {
+export type EditorProps = Omit<PreProps, 'onChange'> & ComponentProps<CodeEditor> & {
   code?: string,
   disabled?: boolean;
   language?: Language;
   onChange?: (code: string) => void;
   theme?: PrismTheme;
-  padding?: number | string;
 }
 
 export const Editor: ComponentClass<EditorProps>

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -28,7 +28,7 @@ export const providerC = (
 );
 
 export const editorC = (
-  <Editor onChange={(code: string) => {}} code="code" disabled={false} />
+  <Editor onChange={(code: string) => {}} code="code" disabled={false} padding={16} />
 );
 
 export const liveEditorC = <LiveEditor onChange={(code: string) => {}} />;


### PR DESCRIPTION
The current type definition for `LiveEditor` doesn't include props that are [passed through to `react-simple-code-editor`](https://github.com/FormidableLabs/react-live/blob/master/src/components/Editor/index.js#L87). This prevents TypeScript consumers from using props like `padding`.  This PR updates the type definition of `LiveEditor` to include `react-simple-code-editor` props.