### PR TITLE
remove onChange prop again before spreading to react-simple-code-editor

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -58,7 +58,8 @@ class CodeEditor extends Component {
   );
 
   render() {
-    const { style, theme, ...rest } = this.props;
+    // eslint-disable-next-line no-unused-vars
+    const { style, theme, onChange, ...rest } = this.props;
     const { code } = this.state;
 
     const baseTheme =


### PR DESCRIPTION
- squashes a bug inadvertently introduced when https://github.com/FormidableLabs/react-live/pull/226 was merged
  - previously we were removing `onChange` (and a few other props) before spreading the `...rest` remainder down to `react-simple-code-editor`
  
- `onChange` gets called with a `SyntheticEvent` (instead of a value) and that in turns throws a bunch of other errors
  
- as a fix i considered removing the props spread entirely and just being more explicit, but it seems like this was originally introduced to (optionally) support spreading handlers like `onFocus` and `onBlur` down to the editor (see https://github.com/FormidableLabs/react-live/pull/6)
  - in the interest of not interfering with event handler spreading, I've just restored the behaviour prior to #226 which was just to swallow `onChange` in the destructuring as an unused var
  
## Before
https://user-images.githubusercontent.com/2393035/123556984-1df04b80-d743-11eb-8283-fbc35b338398.mov

## After
https://user-images.githubusercontent.com/2393035/123556989-247ec300-d743-11eb-8925-014c7dd63962.mov

