### PR TITLE
fix #283: Verify valid element before rendering

### DIFF
--- a/src/utils/transpile/errorBoundary.js
+++ b/src/utils/transpile/errorBoundary.js
@@ -7,7 +7,11 @@ const errorBoundary = (Element, errorCallback) => {
     }
 
     render() {
-      return typeof Element === 'function' ? <Element /> : Element;
+      return typeof Element === 'function' ? (
+        <Element />
+      ) : React.isValidElement(Element) ? (
+        Element
+      ) : null;
     }
   };
 };


### PR DESCRIPTION
[https://github.com/FormidableLabs/react-live/issues/283](url)

Add a React.isValidElement check before rendering to the live playground, preventing a full window crash when entering non-valid child objects such as console, window, document.

See the difference in changes below:
Before - https://www.loom.com/share/ba67749226a546129caa8cc7e33eae09
After - https://www.loom.com/share/0583ebbaaf6c4ccf8f69eaca1a35c9ad

resolves #283