### PR TITLE
Add correct typings for the LivePreview component

### DIFF
--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,37 +1,38 @@
-import { ComponentClass, HTMLProps, ComponentType, Context } from 'react'
-import { PrismTheme, Language } from 'prism-react-renderer';
+import { Language, PrismTheme } from "prism-react-renderer";
+import { ComponentClass, ComponentType, Context, HTMLProps } from "react";
+import React = require("react");
 
 // Helper types
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 // React Element Props
-type DivProps = HTMLProps<HTMLDivElement>
-type PreProps = HTMLProps<HTMLPreElement>
+type DivProps = HTMLProps<HTMLDivElement>;
+type PreProps = HTMLProps<HTMLPreElement>;
 
 // LiveProvider
-export type LiveProviderProps = Omit<DivProps, 'scope'> & {
+export type LiveProviderProps = Omit<DivProps, "scope"> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
-  transformCode?: (code: string) => (string | Promise<string>);
+  transformCode?: (code: string) => string | Promise<string>;
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
-}
+};
 
-export const LiveProvider: ComponentClass<LiveProviderProps>
+export const LiveProvider: ComponentClass<LiveProviderProps>;
 
 // Editor
-export type EditorProps = Omit<PreProps, 'onChange'> & {
-  code?: string,
+export type EditorProps = Omit<PreProps, "onChange"> & {
+  code?: string;
   disabled?: boolean;
   language?: Language;
   onChange?: (code: string) => void;
   theme?: PrismTheme;
-  prism?: unknown
-}
+  prism?: unknown;
+};
 
-export const Editor: ComponentClass<EditorProps>
+export const Editor: ComponentClass<EditorProps>;
 
 // Context
 export interface ContextProps {
@@ -47,13 +48,19 @@ export const LiveContext: Context<ContextProps>;
 // LiveEditor
 export type LiveEditorProps = EditorProps;
 
-export const LiveEditor: ComponentClass<LiveEditorProps>
+export const LiveEditor: ComponentClass<LiveEditorProps>;
 
 // LiveError
-export const LiveError: ComponentClass<DivProps>
+export const LiveError: ComponentClass<DivProps>;
 
 // LivePreview
-export const LivePreview: ComponentClass<DivProps>
+export type LivePreviewProps<T extends DivProps = DivProps> = DivProps & {
+  Component?: React.ComponentType<T>;
+  [key: string]: any;
+};
+export const LivePreview: ComponentClass<LivePreviewProps>;
 
 // withLive HOC
-export function withLive<P>(wrappedComponent: ComponentType<P>): ComponentClass<P>
+export function withLive<P>(
+  wrappedComponent: ComponentType<P>
+): ComponentClass<P>;

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -1,28 +1,28 @@
+import * as React from "react";
 import {
-  LiveProvider,
   Editor,
+  LiveContext,
   LiveEditor,
   LiveError,
   LivePreview,
-  LiveContext,
-  withLive
-} from '../';
-import * as React from 'react';
+  LiveProvider,
+  withLive,
+} from "../";
 
 export const providerC = (
   <LiveProvider
     code="code"
     className="class"
     scope={{ Component: React.Component }}
-    transformCode={(code: string): string => code + ';;'}
+    transformCode={(code: string): string => code + ";;"}
     noInline={false}
     language="typescript"
     theme={{
       plain: {
-        fontWeight: '800',
-        color: 'salmon'
+        fontWeight: "800",
+        color: "salmon",
       },
-      styles: []
+      styles: [],
     }}
   />
 );
@@ -42,6 +42,19 @@ export const customError = () => (
 );
 
 export const livePreviewC = <LivePreview />;
+
+export const liveCustomPreviewC = (
+  <LivePreview Component={(props) => <div {...props} />} />
+);
+
+type BoxProps = { padding: string; children: React.ReactNode };
+const Box = ({ padding, children }: BoxProps) => (
+  <div style={{ padding }}>{children}</div>
+);
+
+export const liveCustomPreviewWithExtraPropsC = (
+  <LivePreview Component={Box} padding="2px" />
+);
 
 const Component: React.StatelessComponent<{}> = () => <div>Hello World!</div>;
 


### PR DESCRIPTION
This pull request adds the correct type definitions for the LivePreview component.

You can pass a `Component` prop to the `<LivePreview />` component, which will let you render a random component, and pass whatever props you want to the surrounding component. That's why the props type suggested here is so accepting. 

There's a way to do this with an as-prop or something similar, but my TypeScript skills doesn't go that far.
