### PR TITLE
add spellCheck=false to stop Editor underlining code

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -52,6 +52,7 @@ const CodeEditor = (props) => {
               ...(!props.className || !props.theme ? {} : _style),
             }}
             ref={editorRef}
+            spellCheck="false"
           >
             {tokens.map((line, lineIndex) => (
               // eslint-disable-next-line react/jsx-key


### PR DESCRIPTION
- fixes https://github.com/FormidableLabs/react-live/issues/310
- fixes https://github.com/FormidableLabs/react-live/issues/315