### PR TITLE
Add on change props

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ It supports these props, while passing any others through to the `children`:
 |language|PropTypes.string|What language you're writing for correct syntax highlighting. (Default: `jsx`)
 |disabled|PropTypes.bool|Disable editing on the `<LiveEditor />` (Default: `false`)
 |theme|PropTypes.object|A `prism-react-renderer` theme object. See more [here](https://github.com/FormidableLabs/prism-react-renderer#theming)
+[onChange|PropTypes.func|Callback for when the code changes
 
 
 All subsequent components must be rendered inside a provider, since they communicate
@@ -200,6 +201,7 @@ This component renders the editor that displays the code. It is a wrapper around
 |Name|PropType|Description|
 |---|---|---|
 |style|PropTypes.object|Allows overriding default styles on the `LiveEditor` component.
+|onChange|PropTypes.func|Callback for when the code changes
 
 
 ### &lt;LiveError /&gt;

--- a/src/components/Live/LiveEditor.js
+++ b/src/components/Live/LiveEditor.js
@@ -1,18 +1,30 @@
 import React, { useContext } from "react";
-import LiveContext from "./LiveContext";
 import Editor from "../Editor";
+import LiveContext from "./LiveContext";
+import PropTypes from "prop-types";
 
-export default function LiveEditor(props) {
-  const { code, language, theme, disabled, onChange } = useContext(LiveContext);
+export default function LiveEditor({ onChange, ...props }) {
+  const liveContext = useContext(LiveContext);
+
+  const handleChange = (code) => {
+    liveContext.onChange(code);
+    if (onChange) {
+      onChange(code);
+    }
+  };
 
   return (
     <Editor
-      theme={theme}
-      code={code}
-      language={language}
-      disabled={disabled}
-      onChange={onChange}
+      theme={liveContext.theme}
+      code={liveContext.code}
+      language={liveContext.language}
+      disabled={liveContext.disabled}
+      onChange={handleChange}
       {...props}
     />
   );
 }
+
+LiveEditor.propTypes = {
+  onChange: PropTypes.func,
+};

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-
-import LiveContext from "./LiveContext";
+import React, { useEffect, useState } from "react";
 import { generateElement, renderElementAsync } from "../../utils/transpile";
+import LiveContext from "./LiveContext";
 
 function LiveProvider({
   children,
@@ -13,6 +12,7 @@ function LiveProvider({
   scope,
   transformCode,
   noInline = false,
+  onChange,
 }) {
   const [state, setState] = useState({
     error: undefined,
@@ -64,7 +64,10 @@ function LiveProvider({
     transpileAsync(code).catch(onError);
   }, [code, scope, noInline, transformCode]);
 
-  const onChange = (newCode) => {
+  const handleChange = (newCode) => {
+    if (onChange) {
+      onChange(newCode);
+    }
     transpileAsync(newCode).catch(onError);
   };
 
@@ -77,7 +80,7 @@ function LiveProvider({
         theme,
         disabled,
         onError,
-        onChange,
+        onChange: handleChange,
       }}
     >
       {children}
@@ -91,6 +94,7 @@ LiveProvider.propTypes = {
   disabled: PropTypes.bool,
   language: PropTypes.string,
   noInline: PropTypes.bool,
+  onChange: PropTypes.func,
   scope: PropTypes.object,
   theme: PropTypes.object,
   transformCode: PropTypes.func,

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -10,7 +10,7 @@ type DivProps = HTMLProps<HTMLDivElement>;
 type PreProps = HTMLProps<HTMLPreElement>;
 
 // LiveProvider
-export type LiveProviderProps = Omit<DivProps, "scope"> & {
+export type LiveProviderProps = Omit<DivProps, "scope" | "onChange"> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
@@ -18,6 +18,7 @@ export type LiveProviderProps = Omit<DivProps, "scope"> & {
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
+  onChange?: (code: string) => void;
 };
 
 export const LiveProvider: ComponentClass<LiveProviderProps>;

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -41,6 +41,7 @@ export interface ContextProps {
   theme: PrismTheme;
   disabled?: boolean;
   error?: string;
+  onChange?: (code: string) => void;
 }
 
 export const LiveContext: Context<ContextProps>;

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -1,37 +1,38 @@
-import { ComponentClass, HTMLProps, ComponentType, Context } from 'react'
-import { PrismTheme, Language } from 'prism-react-renderer';
+import { Language, PrismTheme } from "prism-react-renderer";
+import { ComponentClass, ComponentType, Context, HTMLProps } from "react";
+import React = require("react");
 
 // Helper types
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 // React Element Props
-type DivProps = HTMLProps<HTMLDivElement>
-type PreProps = HTMLProps<HTMLPreElement>
+type DivProps = HTMLProps<HTMLDivElement>;
+type PreProps = HTMLProps<HTMLPreElement>;
 
 // LiveProvider
-export type LiveProviderProps = Omit<DivProps, 'scope'> & {
+export type LiveProviderProps = Omit<DivProps, "scope"> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
-  transformCode?: (code: string) => (string | Promise<string>);
+  transformCode?: (code: string) => string | Promise<string>;
   language?: Language;
   disabled?: boolean;
   theme?: PrismTheme;
-}
+};
 
-export const LiveProvider: ComponentClass<LiveProviderProps>
+export const LiveProvider: ComponentClass<LiveProviderProps>;
 
 // Editor
-export type EditorProps = Omit<PreProps, 'onChange'> & {
-  code?: string,
+export type EditorProps = Omit<PreProps, "onChange"> & {
+  code?: string;
   disabled?: boolean;
   language?: Language;
   onChange?: (code: string) => void;
   theme?: PrismTheme;
-  prism?: unknown
-}
+  prism?: unknown;
+};
 
-export const Editor: ComponentClass<EditorProps>
+export const Editor: ComponentClass<EditorProps>;
 
 // Context
 export interface ContextProps {
@@ -47,13 +48,19 @@ export const LiveContext: Context<ContextProps>;
 // LiveEditor
 export type LiveEditorProps = EditorProps;
 
-export const LiveEditor: ComponentClass<LiveEditorProps>
+export const LiveEditor: ComponentClass<LiveEditorProps>;
 
 // LiveError
-export const LiveError: ComponentClass<DivProps>
+export const LiveError: ComponentClass<DivProps>;
 
 // LivePreview
-export const LivePreview: ComponentClass<DivProps>
+export type LivePreviewProps<T extends DivProps = DivProps> = DivProps & {
+  Component?: React.ComponentType<T>;
+  [key: string]: any;
+};
+export const LivePreview: ComponentClass<LivePreviewProps>;
 
 // withLive HOC
-export function withLive<P>(wrappedComponent: ComponentType<P>): ComponentClass<P>
+export function withLive<P>(
+  wrappedComponent: ComponentType<P>
+): ComponentClass<P>;

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -1,28 +1,28 @@
+import * as React from "react";
 import {
-  LiveProvider,
   Editor,
+  LiveContext,
   LiveEditor,
   LiveError,
   LivePreview,
-  LiveContext,
-  withLive
-} from '../';
-import * as React from 'react';
+  LiveProvider,
+  withLive,
+} from "../";
 
 export const providerC = (
   <LiveProvider
     code="code"
     className="class"
     scope={{ Component: React.Component }}
-    transformCode={(code: string): string => code + ';;'}
+    transformCode={(code: string): string => code + ";;"}
     noInline={false}
     language="typescript"
     theme={{
       plain: {
-        fontWeight: '800',
-        color: 'salmon'
+        fontWeight: "800",
+        color: "salmon",
       },
-      styles: []
+      styles: [],
     }}
   />
 );
@@ -42,6 +42,19 @@ export const customError = () => (
 );
 
 export const livePreviewC = <LivePreview />;
+
+export const liveCustomPreviewC = (
+  <LivePreview Component={(props) => <div {...props} />} />
+);
+
+type BoxProps = { padding: string; children: React.ReactNode };
+const Box = ({ padding, children }: BoxProps) => (
+  <div style={{ padding }}>{children}</div>
+);
+
+export const liveCustomPreviewWithExtraPropsC = (
+  <LivePreview Component={Box} padding="2px" />
+);
 
 const Component: React.StatelessComponent<{}> = () => <div>Hello World!</div>;
 

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -24,6 +24,7 @@ export const providerC = (
       },
       styles: [],
     }}
+    onChange={(code) => {}}
   />
 );
 


### PR DESCRIPTION
This pull request adds onChange props for both the `LiveProvider` and the `LiveEditor` components.

This makes it possible to i.e. save any changes in code in a session or cookie, so the user can continue editing their code on the next visit.

My rationale for adding it both on the provider and editor level is that both places feels natural to me. I don't mind changing the implementation if you disagree.