### PR TITLE
feat(SSR): add support for initial SSR render

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ It supports these props, while passing any others through to the `children`:
 |code|PropTypes.string|The code that should be rendered, apart from the user’s edits
 |scope|PropTypes.object|Accepts custom globals that the `code` can use
 |noInline|PropTypes.bool|Doesn’t evaluate and mount the inline code (Default: `false`). Note: when using `noInline` whatever code you write must be a single expression (function, class component or some `jsx`) that can be returned immediately. If you'd like to render multiple components, use `noInline={true}`
+|skipInitialRender|PropTypes.bool|Skip the initial render used for SSR (Default: `false`)
 |transformCode|PropTypes.func|Accepts and returns the code to be transpiled, affording an opportunity to first transform it
 |language|PropTypes.string|What language you're writing for correct syntax highlighting. (Default: `jsx`)
 |disabled|PropTypes.bool|Disable editing on the `<LiveEditor />` (Default: `false`)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "use-editable": "^2.3.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^12.1.5",
     "@babel/core": "^7.15.0",
     "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
@@ -90,7 +91,6 @@
   ],
   "jest": {
     "testEnvironment": "jsdom",
-    "resetMocks": true,
     "rootDir": "./src",
     "testURL": "http://localhost/"
   },

--- a/src/components/Live/LiveProvider.test.js
+++ b/src/components/Live/LiveProvider.test.js
@@ -1,85 +1,300 @@
 import React, { useContext } from "react";
 import { act } from "react-dom/test-utils";
-import { renderElementAsync } from "../../utils/transpile";
-import { render } from "../../utils/test/renderer";
+import { renderElementAsync, generateElement } from "../../utils/transpile";
+import { render, screen } from "@testing-library/react";
 import LiveProvider from "./LiveProvider";
 import LiveContext from "./LiveContext";
 
-jest.mock("../../utils/transpile");
+jest.mock("../../utils/transpile", () => {
+  const orig = jest.requireActual("../../utils/transpile");
+  return {
+    ...orig,
+
+    // So we still can use/run these methods
+    generateElement: jest.fn().mockImplementation(orig.generateElement),
+    renderElementAsync: jest.fn().mockImplementation(orig.renderElementAsync),
+  };
+});
 
 function waitAsync() {
   return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
 }
 
-it("applies a synchronous transformCode function", () => {
-  function transformCode(code) {
-    return `render(<div>${code}</div>)`;
-  }
-
-  render(<LiveProvider code="hello" noInline transformCode={transformCode} />);
-
-  return waitAsync().then(() => {
-    expect(renderElementAsync).toHaveBeenCalledTimes(1);
-    expect(renderElementAsync.mock.calls[0][0].code).toBe(
-      "render(<div>hello</div>)"
-    );
-  });
-});
-
-it("applies an asynchronous transformCode function", () => {
-  function transformCode(code) {
-    return Promise.resolve(`render(<div>${code}</div>)`);
-  }
-
-  render(<LiveProvider code="hello" noInline transformCode={transformCode} />);
-
-  return waitAsync().then(() => {
-    expect(renderElementAsync).toHaveBeenCalledTimes(1);
-    expect(renderElementAsync.mock.calls[0][0].code).toBe(
-      "render(<div>hello</div>)"
-    );
-  });
-});
-
 function ErrorRenderer() {
   const { error } = useContext(LiveContext);
-  return <div data-testid="handledError">{error?.message}</div>;
+  return <div data-testid="handledError">{error?.message || error}</div>;
 }
 
-it("catches errors from a synchronous transformCode function", () => {
-  function transformCode() {
-    throw new Error("testError");
-  }
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.clearAllMocks();
+});
 
-  const wrapper = render(
-    <LiveProvider code="hello" noInline transformCode={transformCode}>
-      <ErrorRenderer />
-    </LiveProvider>
-  );
+describe("LiveProvider with skipInitialRender", () => {
+  it("applies a synchronous transformCode function", (done) => {
+    function transformCode(code) {
+      return `render(<div>${code}</div>)`;
+    }
 
-  return waitAsync().then(() => {
-    expect(renderElementAsync).not.toHaveBeenCalled();
+    render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={transformCode}
+        skipInitialRender // do not count the initial render
+      />
+    );
 
-    const handledErrorWrapper = wrapper.find('[data-testid="handledError"]');
-    expect(handledErrorWrapper.text()).toBe("testError");
+    expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(1);
+      expect(renderElementAsync.mock.calls[0][0].code).toBe(
+        "render(<div>hello</div>)"
+      );
+
+      done();
+    });
+  });
+
+  it("applies an asynchronous transformCode function", (done) => {
+    function transformCode(code) {
+      return Promise.resolve(`render(<div>${code}</div>)`);
+    }
+
+    render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={transformCode}
+        skipInitialRender // do not count the initial render
+      />
+    );
+
+    expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(1);
+      expect(renderElementAsync.mock.calls[0][0].code).toBe(
+        "render(<div>hello</div>)"
+      );
+
+      done();
+    });
+  });
+
+  it("catches errors from a synchronous transformCode function", (done) => {
+    function transformCode() {
+      throw new Error("testError");
+    }
+
+    render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={transformCode}
+        skipInitialRender
+      >
+        <ErrorRenderer />
+      </LiveProvider>
+    );
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+      const handledErrorWrapper = screen.getByTestId("handledError");
+      expect(handledErrorWrapper.textContent).toBe("Error: testError");
+
+      done();
+    });
+  });
+
+  it("catches errors from an asynchronous transformCode function", (done) => {
+    function transformCode() {
+      return Promise.reject(new Error("testError"));
+    }
+
+    render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={transformCode}
+        skipInitialRender
+      >
+        <ErrorRenderer />
+      </LiveProvider>
+    );
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+      const handledErrorWrapper = screen.getByTestId("handledError");
+      expect(handledErrorWrapper.textContent).toBe("Error: testError");
+
+      done();
+    });
+  });
+
+  it("will skip ssr render", (done) => {
+    function transformCode(code) {
+      return `render(<div>${code}</div>)`;
+    }
+
+    render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={transformCode}
+        skipInitialRender
+      />
+    );
+
+    expect(generateElement).toHaveBeenCalledTimes(0);
+    expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(1);
+      expect(renderElementAsync.mock.calls[0][0].code).toBe(
+        "render(<div>hello</div>)"
+      );
+
+      done();
+    });
   });
 });
 
-it("catches errors from an asynchronous transformCode function", () => {
-  function transformCode() {
-    return Promise.reject(new Error("testError"));
-  }
+describe("LiveProvider with ssr support", () => {
+  it("will apply synchronous transformCode function on initial render", (done) => {
+    function transformCode(code) {
+      return `<div>${code}</div>`;
+    }
 
-  const wrapper = render(
-    <LiveProvider code="hello" noInline transformCode={transformCode}>
-      <ErrorRenderer />
-    </LiveProvider>
-  );
+    render(
+      <LiveProvider
+        code="hello"
+        noInline={false}
+        transformCode={transformCode}
+      />
+    );
 
-  return waitAsync().then(() => {
-    expect(renderElementAsync).not.toHaveBeenCalled();
+    function assert() {
+      expect(generateElement).toHaveBeenCalledTimes(1);
+      expect(generateElement.mock.calls[0][0].code).toBe("<div>hello</div>");
+      expect(renderElementAsync).toHaveBeenCalledTimes(0);
+    }
 
-    const handledErrorWrapper = wrapper.find('[data-testid="handledError"]');
-    expect(handledErrorWrapper.text()).toBe("testError");
+    assert();
+
+    waitAsync().then(() => {
+      assert();
+      done();
+    });
+  });
+
+  it("will apply asynchronous transformCode function on initial render", (done) => {
+    function transformCode(code) {
+      return `render(<div>${code}</div>)`;
+    }
+
+    render(
+      <LiveProvider code="hello" noInline transformCode={transformCode} />
+    );
+
+    function assert() {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(1);
+      expect(renderElementAsync.mock.calls[0][0].code).toBe(
+        "render(<div>hello</div>)"
+      );
+    }
+
+    assert();
+
+    waitAsync().then(() => {
+      assert();
+      done();
+    });
+  });
+
+  it("will rerender on property changes while supporting ssr", (done) => {
+    const { rerender } = render(
+      <LiveProvider
+        code="hello"
+        noInline
+        transformCode={(code) => `render(<div>${code}</div>)`}
+      />
+    );
+
+    expect(generateElement).toHaveBeenCalledTimes(0);
+    expect(renderElementAsync).toHaveBeenCalledTimes(1);
+    expect(renderElementAsync.mock.calls[0][0].code).toBe(
+      "render(<div>hello</div>)"
+    );
+
+    rerender(
+      <LiveProvider
+        code="changed code"
+        noInline
+        transformCode={(code) => `render(<div>${code}</div>)`}
+      />
+    );
+
+    waitAsync().then(() => {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(2);
+      expect(renderElementAsync.mock.calls[1][0].code).toBe(
+        "render(<div>changed code</div>)"
+      );
+
+      rerender(
+        <LiveProvider
+          code="changed code to inline"
+          transformCode={(code) => `<div>${code}</div>`}
+        />
+      );
+
+      waitAsync().then(() => {
+        expect(generateElement).toHaveBeenCalledTimes(1);
+        expect(generateElement.mock.calls[0][0].code).toBe(
+          "<div>changed code to inline</div>"
+        );
+        expect(renderElementAsync).toHaveBeenCalledTimes(2);
+
+        done();
+      });
+    });
+  });
+
+  it("catches errors from a synchronous transformCode function", (done) => {
+    function transformCode() {
+      throw new Error("testError");
+    }
+
+    render(
+      <LiveProvider code="hello" noInline transformCode={transformCode}>
+        <ErrorRenderer />
+      </LiveProvider>
+    );
+
+    function assert() {
+      expect(generateElement).toHaveBeenCalledTimes(0);
+      expect(renderElementAsync).toHaveBeenCalledTimes(0);
+
+      expect(screen.getByTestId("handledError").textContent).toBe(
+        "Error: testError"
+      );
+    }
+
+    assert();
+
+    waitAsync().then(() => {
+      assert();
+      done();
+    });
   });
 });

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -13,6 +13,7 @@ export type LiveProviderProps = Omit<DivProps, 'scope'> & {
   scope?: { [key: string]: any };
   code?: string;
   noInline?: boolean;
+  skipInitialRender?: boolean;
   transformCode?: (code: string) => (string | Promise<string>);
   language?: Language;
   disabled?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,10 +2369,38 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
+"@testing-library/dom@^8.0.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^12.1.5":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.15"
@@ -2565,6 +2593,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-dom@<18.0.0":
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
+  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -2576,6 +2611,15 @@
   version "17.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
   integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
+  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3103,6 +3147,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4789,6 +4838,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -7959,6 +8013,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -9473,6 +9532,15 @@ pretty-error@^2.1.1:
   dependencies:
     lodash "^4.17.20"
     renderkid "^2.0.4"
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^27.0.6:
   version "27.0.6"


### PR DESCRIPTION
Fixes #321 (more details in this issue)

This PR adds support for in "initial sync render". With that, we do support SSR again.

- A new property to skip that behavior was added: `skipInitialRender`.
- For performance reasons we run the initial render once and omit the second from inside useEffect – else the code render would have to render twice.

There may be ways to write less code, or to combine `transpileSync` and `transpileAsync` – but when I did that, it got less readable and feels bloated. Anyway, maybe someone else want have a try?

**Test plan**

- Added some tests to verify that initial render.
- I needed to remove `"resetMocks": true,` jest config in the `package.json` so mocking of `generateElement` was possible, but use the original at the same time.
- Most of the `LiveProvider.test.js` test where giving false positives, as the `return waitAsync` never got called. 
- In order to actually make `useEffect` work (called) – I changed the jsdom renderer to `@testing-library/react`.
