### PR TITLE
feat(CodeEditor): support forwarding props to pre element

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ This component renders the editor that displays the code. It is a wrapper around
 |Name|PropType|Description|
 |---|---|---|
 |style|PropTypes.object|Allows overriding default styles on the `LiveEditor` component.
+|editorRef|PropTypes.object|Provide your own React Ref to reference the `pre` HTLM element
 
 
 ### &lt;LiveError /&gt;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rollup/plugin-replace": "^3.0.0",
     "@storybook/addon-controls": "^6.4.13",
     "@storybook/react": "^6.4.13",
+    "@testing-library/react": "^12.1.5",
     "@types/react": "^17.0.38",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",

--- a/src/components/Editor/CodeEditor.test.js
+++ b/src/components/Editor/CodeEditor.test.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import CodeEditor from "./index";
+
+describe("CodeEditor", () => {
+  it("should render pre element", () => {
+    const code = /* jsx */ `render(<div>code</div>)`;
+
+    render(<CodeEditor code={code} data-testid="code-editor" />);
+
+    const preElement = screen.getByTestId("code-editor");
+
+    expect(preElement.tagName).toBe("PRE");
+  });
+
+  it("should forward props to pre element", () => {
+    const code = /* jsx */ `render(<div>code</div>)`;
+
+    render(
+      <CodeEditor
+        code={code}
+        data-testid="code-editor"
+        aria-label="custom-label"
+      />
+    );
+
+    const preElement = screen.getByTestId("code-editor");
+
+    expect(preElement.getAttribute("aria-label")).toBe("custom-label");
+  });
+
+  it("should omit v2 props", () => {
+    const code = /* jsx */ `render(<div>code</div>)`;
+
+    render(
+      <CodeEditor
+        code={code}
+        data-testid="code-editor"
+        textareaId="id"
+        ignoreTabKey="id"
+        padding={0}
+      />
+    );
+
+    const preElement = screen.getByTestId("code-editor");
+
+    const attributes = Array.from(preElement.attributes).map(
+      (attr) => attr.name
+    );
+    expect(attributes).toEqual(["class", "style", "spellcheck", "data-testid"]);
+  });
+
+  it("should support custom ref given by editorRef", () => {
+    const ref = React.createRef();
+    const code = /* jsx */ `render(<div>code</div>)`;
+
+    render(
+      <CodeEditor code={code} data-testid="code-editor" editorRef={ref} />
+    );
+
+    const preElement = screen.getByTestId("code-editor");
+
+    expect(ref.current).toBe(preElement);
+  });
+
+  it("should forward onFocus and onBlur", () => {
+    const code = /* jsx */ `render(<div>code</div>)`;
+
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+
+    render(
+      <CodeEditor
+        code={code}
+        data-testid="code-editor"
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
+
+    const preElement = screen.getByTestId("code-editor");
+
+    fireEvent.focus(preElement);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+
+    fireEvent.blur(preElement);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -5,35 +5,53 @@ import Highlight, { Prism } from "prism-react-renderer";
 import { theme as liveTheme } from "../../constants/theme";
 
 const CodeEditor = (props) => {
-  const editorRef = useRef(null);
-  const [code, setCode] = useState(props.code || "");
+  const {
+    code: origCode,
+    className,
+    style,
+    theme,
+    prism,
+    language,
+    disabled,
+    onChange,
+    editorRef,
+
+    // Remove v2 props from beeing forwarded
+    textareaId, // eslint-disable-line
+    ignoreTabKey, // eslint-disable-line
+    padding, // eslint-disable-line
+    ...rest
+  } = props;
+
+  const _editorRef = editorRef || useRef(null);
+  const [code, setCode] = useState(origCode || "");
 
   useEffect(() => {
-    setCode(props.code);
-  }, [props.code]);
+    setCode(origCode);
+  }, [origCode]);
 
   const onEditableChange = useCallback((_code) => {
     setCode(_code.slice(0, -1));
   }, []);
 
-  useEditable(editorRef, onEditableChange, {
-    disabled: props.disabled,
+  useEditable(_editorRef, onEditableChange, {
+    disabled,
     indentation: 2,
   });
 
   useEffect(() => {
-    if (props.onChange) {
-      props.onChange(code);
+    if (onChange) {
+      onChange(code);
     }
   }, [code]);
 
   return (
-    <div className={props.className} style={props.style}>
+    <div className={className} style={style}>
       <Highlight
-        Prism={props.prism || Prism}
+        Prism={prism || Prism}
         code={code}
-        theme={props.theme || liveTheme}
-        language={props.language}
+        theme={theme || liveTheme}
+        language={language}
       >
         {({
           className: _className,
@@ -49,10 +67,11 @@ const CodeEditor = (props) => {
               outline: "none",
               padding: 10,
               fontFamily: "inherit",
-              ...(!props.className || !props.theme ? {} : _style),
+              ...(!className || !theme ? {} : _style),
             }}
             ref={editorRef}
             spellCheck="false"
+            {...rest}
           >
             {tokens.map((line, lineIndex) => (
               // eslint-disable-next-line react/jsx-key
@@ -79,6 +98,7 @@ CodeEditor.propTypes = {
   className: PropTypes.string,
   code: PropTypes.string,
   disabled: PropTypes.bool,
+  editorRef: PropTypes.object,
   language: PropTypes.string,
   onChange: PropTypes.func,
   prism: PropTypes.object,

--- a/typings/react-live.d.ts
+++ b/typings/react-live.d.ts
@@ -28,7 +28,8 @@ export type EditorProps = Omit<PreProps, 'onChange'> & {
   language?: Language;
   onChange?: (code: string) => void;
   theme?: PrismTheme;
-  prism?: unknown
+  prism?: unknown;
+  editorRef?: React.RefObject<HTMLPreElement>;
 }
 
 export const Editor: ComponentClass<EditorProps>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,10 +2369,38 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
+"@testing-library/dom@^8.0.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^12.1.5":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.15"
@@ -2565,6 +2593,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-dom@<18.0.0":
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
+  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -2576,6 +2611,15 @@
   version "17.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
   integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
+  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3103,6 +3147,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4789,6 +4838,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -7959,6 +8013,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -9473,6 +9532,15 @@ pretty-error@^2.1.1:
   dependencies:
     lodash "^4.17.20"
     renderkid "^2.0.4"
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^27.0.6:
   version "27.0.6"


### PR DESCRIPTION
This PR supports forwarding of props to the pre element. This allows to set e.g. unique ID for using a label. Or also `aria-label` will do it (Its important that it is set to the actual element) and not on a wrapper div.

**Test plan**

In order to test this component properly, I added `@testing-library/react` including tests for cases I think needed to be tested.