### PR TITLE
Fix: Apply theme changes.

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -41,6 +41,7 @@ const CodeEditor = (props) => {
           getLineProps,
           getTokenProps,
           style: _style,
+          theme: _theme,
         }) => (
           <pre
             className={_className}
@@ -49,7 +50,10 @@ const CodeEditor = (props) => {
               outline: "none",
               padding: 10,
               fontFamily: "inherit",
-              ...(!props.className || !props.theme ? {} : _style),
+              ...(_theme && typeof _theme.plain === "object"
+                ? _theme.plain
+                : {}),
+              ..._style,
             }}
             ref={editorRef}
             spellCheck="false"

--- a/stories/Live.js
+++ b/stories/Live.js
@@ -226,6 +226,7 @@ export const Default = DefaultTemplate.bind({});
 Default.args = {
   ...defaultControls,
   code: code,
+  theme: theme,
 };
 
 export const FunctionExample = StyledPreviewTemplate.bind({});


### PR DESCRIPTION
**Status**: WIP -- we don't have great test coverage here, so I'm mostly manually looking at Storybooks. Would love some more eyes on if anything _else_ changes from this feature.

## Background

We changed how the theme / style applies [here](https://github.com/FormidableLabs/react-live/commit/2265d8dbca01631486f89de3b50753ead160d41c#diff-36a5a8b972ef005a146943557d3eda53686dd70c19c4da1c7c8a3c5301c8e17bL55-R47). If I'm reading this correctly, we originally detected if a base theme was provided on props, then applied that, then overrode with styles coming after.

## Issue

See https://github.com/FormidableLabs/react-live/issues/303

## Fix

I've tried to re-implement the original theme overriding behavior. And I've tweaked the default live example to take in the theme object.

- The default live example now shows a different background color: http://localhost:9001/?path=/story/live--default&args=theme.plain.backgroundColor:red
- The already working styled live example continues working with a different background: http://localhost:9001/?path=/story/live--component-with-theme&args=theme.plain.backgroundColor:magenta

@GilmarLira @oliviadawd -- can you kick the tires on this and report if everything still works (and if the fix works)? Thanks!