### PR TITLE
fix: fix Support for defaultProps will be removed from function compo…

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -5,6 +5,7 @@ import { useEditable } from "use-editable";
 import { theme as liveTheme } from "../../constants/theme";
 
 const CodeEditor = (props) => {
+  const { tabMode = "indentation" } = props;
   const editorRef = useRef(null);
   const [code, setCode] = useState(props.code || "");
 
@@ -18,7 +19,7 @@ const CodeEditor = (props) => {
 
   useEditable(editorRef, onEditableChange, {
     disabled: props.disabled,
-    indentation: props.tabMode === "indentation" ? 2 : undefined,
+    indentation: tabMode === "indentation" ? 2 : undefined,
   });
 
   useEffect(() => {
@@ -89,10 +90,6 @@ CodeEditor.propTypes = {
   style: PropTypes.object,
   tabMode: PropTypes.oneOf(["focus", "indentation"]),
   theme: PropTypes.object,
-};
-
-CodeEditor.defaultProps = {
-  tabMode: "indentation",
 };
 
 export default CodeEditor;

--- a/src/components/Live/LivePreview.js
+++ b/src/components/Live/LivePreview.js
@@ -2,17 +2,13 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import LiveContext from "./LiveContext";
 
-function LivePreview({ Component, ...rest }) {
+function LivePreview({ Component = "div", ...rest }) {
   const { element: Element } = useContext(LiveContext);
   return <Component {...rest}>{Element ? <Element /> : null}</Component>;
 }
 
 LivePreview.propTypes = {
   Component: PropTypes.node,
-};
-
-LivePreview.defaultProps = {
-  Component: "div",
 };
 
 export default LivePreview;

--- a/src/components/Live/LiveProvider.js
+++ b/src/components/Live/LiveProvider.js
@@ -6,10 +6,10 @@ import { generateElement, renderElementAsync } from "../../utils/transpile";
 
 function LiveProvider({
   children,
-  code,
-  language,
+  code = "",
+  language = "jsx",
   theme,
-  disabled,
+  disabled = "false",
   scope,
   transformCode,
   noInline = false,
@@ -94,13 +94,6 @@ LiveProvider.propTypes = {
   scope: PropTypes.object,
   theme: PropTypes.object,
   transformCode: PropTypes.func,
-};
-
-LiveProvider.defaultProps = {
-  code: "",
-  noInline: false,
-  language: "jsx",
-  disabled: false,
 };
 
 export default LiveProvider;


### PR DESCRIPTION
fix warning
Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead

<img width="880" alt="截屏2023-03-26 17 59 50" src="https://user-images.githubusercontent.com/33956589/227768610-f2aaa6f2-9c23-4019-93bc-8a1eb834e682.png">
 