### PR TITLE
Fix LivePreview types

### DIFF
--- a/src/components/Live/LivePreview.tsx
+++ b/src/components/Live/LivePreview.tsx
@@ -1,15 +1,15 @@
 import React, { PropsWithChildren, useContext } from "react";
 import LiveContext from "./LiveContext";
 
-type Props = {
-  Component?: React.ComponentType<PropsWithChildren<Record<string, unknown>>>;
-};
+type Props<T extends React.ElementType = React.ElementType> = {
+  Component?: T;
+} & React.ComponentPropsWithoutRef<T>;
 
-const fallbackComponent = (
-  props: PropsWithChildren<Record<string, unknown>>
-) => <div {...props} />;
-
-function LivePreview({ Component = fallbackComponent, ...rest }: Props) {
+function LivePreview<T extends keyof JSX.IntrinsicElements>(
+  props: Props<T>
+): JSX.Element;
+function LivePreview<T extends React.ElementType>(props: Props<T>): JSX.Element;
+function LivePreview({ Component = "div", ...rest }: Props): JSX.Element {
   const { element: Element } = useContext(LiveContext);
   return <Component {...rest}>{Element ? <Element /> : null}</Component>;
 }


### PR DESCRIPTION
`LivePreview` forwards all props to the rendered `Component`, but the current types doesn't allow you to do so because they aren't explicitly defined in the `Props` type.  In my code, it was showing an error when I was trying to pass `className` into `LivePreview`.

This PR changes the types so that the rest of the props can be inferred from what type of component is used.

I also removed `fallbackComponent` because you can do the same thing by using a default param of `"div"`