### PR TITLE
Fix live preview types

### DIFF
--- a/.changeset/nice-ligers-leave.md
+++ b/.changeset/nice-ligers-leave.md
@@ -2,4 +2,4 @@
 "react-live": patch
 ---
 
-Fix live preview types.
+Fix live preview types. @kyletsang

--- a/.changeset/nice-ligers-leave.md
+++ b/.changeset/nice-ligers-leave.md
@@ -1,0 +1,5 @@
+---
+"react-live": patch
+---
+
+Fix live preview types.

--- a/packages/react-live/src/components/Live/LivePreview.tsx
+++ b/packages/react-live/src/components/Live/LivePreview.tsx
@@ -1,15 +1,16 @@
-import React, { PropsWithChildren, useContext } from "react";
+import React, { useContext } from "react";
 import LiveContext from "./LiveContext";
 
-type Props = {
-  Component?: React.ComponentType<PropsWithChildren<Record<string, unknown>>>;
-};
+type Props<T extends React.ElementType = React.ElementType> = {
+  Component?: T;
+} & React.ComponentPropsWithoutRef<T>;
 
-const fallbackComponent = (
-  props: PropsWithChildren<Record<string, unknown>>
-) => <div {...props} />;
+function LivePreview<T extends keyof JSX.IntrinsicElements>(
+  props: Props<T>
+): JSX.Element;
+function LivePreview<T extends React.ElementType>(props: Props<T>): JSX.Element;
 
-function LivePreview({ Component = fallbackComponent, ...rest }: Props) {
+function LivePreview({ Component = "div", ...rest }: Props): JSX.Element {
   const { element: Element } = useContext(LiveContext);
   return <Component {...rest}>{Element ? <Element /> : null}</Component>;
 }


### PR DESCRIPTION
Implementing #349 on the new directory structure and adding a changeset

👇🏻 see the two different usages 

<img width="682" alt="Screenshot 2023-05-10 at 11 42 32 AM" src="https://github.com/FormidableLabs/react-live/assets/1738349/982718c9-b407-4cc6-98e4-502f4bcd3abb">

<img width="658" alt="Screenshot 2023-05-10 at 11 43 02 AM" src="https://github.com/FormidableLabs/react-live/assets/1738349/534ce7aa-9cb4-4e60-aac1-def5abbb70d6">
