### PR TITLE
Fix ability to insert a new line at the end of the editor.

### DIFF
--- a/.changeset/fair-glasses-protect.md
+++ b/.changeset/fair-glasses-protect.md
@@ -1,0 +1,5 @@
+---
+"react-live": patch
+---
+
+Fix ability to insert a new line at the end of the editor.

--- a/packages/react-live/src/components/Editor/index.tsx
+++ b/packages/react-live/src/components/Editor/index.tsx
@@ -23,7 +23,7 @@ const CodeEditor = (props: Props) => {
     setCode(props.code);
   }, [props.code]);
 
-  useEditable(editorRef, (text) => setCode(text.trimEnd()), {
+  useEditable(editorRef, (text) => setCode(text.slice(0, -1)), {
     disabled: props.disabled,
     indentation: props.tabMode === "indentation" ? 2 : undefined,
   });


### PR DESCRIPTION
`.trim()` removed all ability to insert a new line. We want to just splice out the last character instead so a new carriage return can be added.

https://github.com/FormidableLabs/react-live/assets/1738349/0f081ce0-d19e-4187-8d01-c26e3ef156c5

