### PR TITLE
Set peer deps for React, fix PRR version

### DIFF
--- a/.changeset/tasty-camels-smell.md
+++ b/.changeset/tasty-camels-smell.md
@@ -1,0 +1,5 @@
+---
+"react-live": patch
+---
+
+Fix version and peer deps.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "pnpm changeset version && pnpm install --no-frozen-lockfile"
   },
   "dependencies": {
-    "prism-react-renderer": "^2.0.4"
+    "prism-react-renderer": "2.0.5"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.15.0",

--- a/packages/react-live/package.json
+++ b/packages/react-live/package.json
@@ -20,9 +20,13 @@
     "lint:fix": "eslint --ext .js,.ts,.tsx src --fix"
   },
   "dependencies": {
-    "prism-react-renderer": "*",
+    "prism-react-renderer": "2.0.5",
     "sucrase": "^3.31.0",
     "use-editable": "^2.3.3"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "devDependencies": {
     "shx": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ importers:
   .:
     dependencies:
       prism-react-renderer:
-        specifier: ^2.0.4
-        version: 2.0.4(react@18.2.0)
+        specifier: 2.0.5
+        version: 2.0.5(react@18.2.0)
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.15.0
@@ -100,8 +100,8 @@ importers:
   packages/react-live:
     dependencies:
       prism-react-renderer:
-        specifier: '*'
-        version: 2.0.3(react@18.2.0)
+        specifier: 2.0.5
+        version: 2.0.5(react@18.2.0)
       sucrase:
         specifier: ^3.31.0
         version: 3.31.0
@@ -15238,8 +15238,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /prism-react-renderer@2.0.4(react@18.2.0):
-    resolution: {integrity: sha512-1fcayBPhlGWLjKHeZMA2eJbvLsq1YJsoP3CUOF0BNlobw4knAYS6EWHYawywaZ5zoIxYkgxuqrrkCj7b+135ow==}
+  /prism-react-renderer@2.0.5(react@18.2.0):
+    resolution: {integrity: sha512-VHTC2ZhOImeC3/mu/3TkEuRCa1K+kTCZQeCkwvWzQa01/ahU3dibyxWf3XiPLuO4k/rGjSTea1lEsfza6fMofw==}
     peerDependencies:
       react: '>=16.0.0'
     dependencies:


### PR DESCRIPTION
We missed the peer deps for React in this library, this adds those in and sets `prism-react-renderer` version explicitly in root and the library package.