### PR TITLE
Fix: mv wrapReturn behind transform

### DIFF
--- a/packages/react-live/src/utils/test/fixtures/optional-chain.test.js
+++ b/packages/react-live/src/utils/test/fixtures/optional-chain.test.js
@@ -1,0 +1,23 @@
+import { generateElement } from "../../transpile";
+import { shallow } from "../renderer";
+
+describe("transpile", () => {
+  it("should support optional chain", () => {
+    const code = `function Demo() {
+        return <h3 style={{
+            background: 'darkslateblue',
+            color: 'white',
+            padding: 8,
+            borderRadius: 4
+        }}>
+            {'1'?.toString()}
+        </h3>
+        }`;
+    const Component = generateElement({ code });
+    const wrapper = shallow(<Component />);
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      `"<h3 style=\\"background:darkslateblue;color:white;padding:8px;border-radius:4px\\">1</h3>"`
+    );
+  });
+});

--- a/packages/react-live/src/utils/transpile/index.ts
+++ b/packages/react-live/src/utils/transpile/index.ts
@@ -35,10 +35,10 @@ export const generateElement = (
   const transformed = compose<string>(
     addJsxConst,
     transform({ transforms: ["imports"] }),
-    wrapReturn,
     spliceJsxConst,
     trimCode,
     transform({ transforms: firstPassTransforms }),
+    wrapReturn,
     trimCode
   )(code);
 


### PR DESCRIPTION
Solve this https://github.com/FormidableLabs/react-live/issues/381

<img width="951" alt="image" src="https://github.com/FormidableLabs/react-live/assets/58261676/9579acb2-5f15-4141-8771-339a68ccfa84">

When Sucrase compiles the optional chaining syntax, it generates a function called _optionalChain. If we wrap it with a return statement during the first transform, it can lead to certain issues.

This is the output after the first transform and wrapping with a return. Clearly, it's no longer a valid JavaScript syntax. To solve this problem, we can move the wrapReturn to after the second transform

```tsx
return (function _optionalChain(ops) { let lastAccessLHS = undefined; let value = ops[0]; let i = 1; while (i < ops.length) { const op = ops[i]; const fn = ops[i + 1]; i += 2; if ((op === 'optionalAccess' || op === 'optionalCall') && value == null) { return undefined; } if (op === 'access' || op === 'optionalAccess') { lastAccessLHS = value; value = fn(value); } else if (op === 'call' || op === 'optionalCall') { value = fn((...args) => value.call(lastAccessLHS, ...args)); lastAccessLHS = undefined; } } return value; }function Demo() {
    console.log('???',_optionalChain(['1', 'optionalAccess', _ => _.toString, 'call', _2 => _2()]));
    return React.createElement('h3', { style: {
      background: 'darkslateblue',
      color: 'white',
      padding: 8,
      borderRadius: 4
    }, __self: this, __source: {fileName: _jsxFileName, lineNumber: 3}}, "Hello World! 👋"

    )
    })
```