### PR TITLE
fix: wrap preview in boundary

### DIFF
--- a/.changeset/silent-ads-sell.md
+++ b/.changeset/silent-ads-sell.md
@@ -1,0 +1,5 @@
+---
+"react-live": patch
+---
+
+Wrap preview in error boundary

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,9 +1,6 @@
 name: Code Check
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -16,8 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - name: Check Code ${{ matrix.node-version }}
+      - name: Check Code
         run: pnpm lint
 
-      - name: Build ${{ matrix.node-version }}
+      - name: Test
+        run: pnpm test
+
+      - name: Build
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: react-live Release Workflow
+name: Release Workflow
 
 on:
   push:
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+
+      - name: Check Code
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
 
       - name: Build packages
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:lib": "pnpm run --filter react-live build",
     "lint": "pnpm run --parallel lint",
     "lint:fix": "pnpm run --parallel lint --fix",
+    "test": "pnpm run --filter react-live test",
     "changeset": "changeset",
     "version": "pnpm changeset version && pnpm install --no-frozen-lockfile"
   },

--- a/packages/react-live/src/components/Live/ErrorBoundary.tsx
+++ b/packages/react-live/src/components/Live/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import { Component, ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  onError?: (error: Error) => void;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(err: Error): void {
+    this.props.onError?.(err);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/react-live/src/components/Live/LiveContext.ts
+++ b/packages/react-live/src/components/Live/LiveContext.ts
@@ -5,6 +5,7 @@ type ContextValue = {
   error?: string;
   element?: ComponentType | null;
   code: string;
+  newCode?: string;
   disabled: boolean;
   language: string;
   theme?: typeof themes.nightOwl;

--- a/packages/react-live/src/components/Live/LivePreview.tsx
+++ b/packages/react-live/src/components/Live/LivePreview.tsx
@@ -16,12 +16,7 @@ function LivePreview({ Component = "div", ...rest }: Props): JSX.Element {
   const { element: Element, onError, newCode } = useContext(LiveContext);
 
   return (
-    <ErrorBoundary
-      key={newCode}
-      onError={(err) => {
-        onError(err);
-      }}
-    >
+    <ErrorBoundary key={newCode} onError={onError}>
       <Component {...rest}>{Element ? <Element /> : null}</Component>
     </ErrorBoundary>
   );

--- a/packages/react-live/src/components/Live/LivePreview.tsx
+++ b/packages/react-live/src/components/Live/LivePreview.tsx
@@ -29,6 +29,10 @@ class ErrorBoundary extends Component<
   }
 
   render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
     return this.props.children;
   }
 }
@@ -39,11 +43,11 @@ function LivePreview<T extends keyof JSX.IntrinsicElements>(
 function LivePreview<T extends React.ElementType>(props: Props<T>): JSX.Element;
 
 function LivePreview({ Component = "div", ...rest }: Props): JSX.Element {
-  const { element: Element, onError, code } = useContext(LiveContext);
+  const { element: Element, onError, newCode } = useContext(LiveContext);
 
   return (
     <ErrorBoundary
-      key={code}
+      key={newCode}
       onError={(err) => {
         onError(err);
       }}

--- a/packages/react-live/src/components/Live/LivePreview.tsx
+++ b/packages/react-live/src/components/Live/LivePreview.tsx
@@ -1,41 +1,11 @@
-import React, { useContext, Component } from "react";
+import React, { useContext } from "react";
+
+import { ErrorBoundary } from "./ErrorBoundary";
 import LiveContext from "./LiveContext";
 
 type Props<T extends React.ElementType = React.ElementType> = {
   Component?: T;
 } & React.ComponentPropsWithoutRef<T>;
-
-class ErrorBoundary extends Component<
-  {
-    children: React.ReactNode;
-    onError?: (error: Error) => void;
-  },
-  { hasError: boolean }
-> {
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  constructor(props: {
-    children: React.ReactNode;
-    onError: (error: Error) => void;
-  }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  componentDidCatch(err: Error): void {
-    this.props.onError?.(err);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return null;
-    }
-
-    return this.props.children;
-  }
-}
 
 function LivePreview<T extends keyof JSX.IntrinsicElements>(
   props: Props<T>

--- a/packages/react-live/src/components/Live/LivePreview.tsx
+++ b/packages/react-live/src/components/Live/LivePreview.tsx
@@ -1,9 +1,37 @@
-import React, { useContext } from "react";
+import React, { useContext, Component } from "react";
 import LiveContext from "./LiveContext";
 
 type Props<T extends React.ElementType = React.ElementType> = {
   Component?: T;
 } & React.ComponentPropsWithoutRef<T>;
+
+class ErrorBoundary extends Component<
+  {
+    children: React.ReactNode;
+    onError?: (error: Error) => void;
+  },
+  { hasError: boolean }
+> {
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  constructor(props: {
+    children: React.ReactNode;
+    onError: (error: Error) => void;
+  }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(err: Error): void {
+    this.props.onError?.(err);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
 
 function LivePreview<T extends keyof JSX.IntrinsicElements>(
   props: Props<T>
@@ -11,7 +39,17 @@ function LivePreview<T extends keyof JSX.IntrinsicElements>(
 function LivePreview<T extends React.ElementType>(props: Props<T>): JSX.Element;
 
 function LivePreview({ Component = "div", ...rest }: Props): JSX.Element {
-  const { element: Element } = useContext(LiveContext);
-  return <Component {...rest}>{Element ? <Element /> : null}</Component>;
+  const { element: Element, onError, code } = useContext(LiveContext);
+
+  return (
+    <ErrorBoundary
+      key={code}
+      onError={(err) => {
+        onError(err);
+      }}
+    >
+      <Component {...rest}>{Element ? <Element /> : null}</Component>
+    </ErrorBoundary>
+  );
 }
 export default LivePreview;

--- a/packages/react-live/src/components/Live/LiveProvider.tsx
+++ b/packages/react-live/src/components/Live/LiveProvider.tsx
@@ -6,6 +6,7 @@ import { themes } from "prism-react-renderer";
 type ProviderState = {
   element?: ComponentType | null;
   error?: string;
+  newCode?: string;
 };
 
 type Props = {
@@ -37,7 +38,11 @@ function LiveProvider({
 
   async function transpileAsync(newCode: string) {
     const errorCallback = (error: Error) => {
-      setState({ error: error.toString(), element: undefined });
+      setState((previousState) => ({
+        ...previousState,
+        error: error.toString(),
+        element: undefined,
+      }));
     };
 
     // - transformCode may be synchronous or asynchronous.
@@ -51,7 +56,7 @@ function LiveProvider({
       try {
         const transformedCode = await Promise.resolve(transformResult);
         const renderElement = (element: ComponentType) =>
-          setState({ error: undefined, element });
+          setState({ error: undefined, element, newCode });
 
         if (typeof transformedCode !== "string") {
           throw new Error("Code failed to transform");
@@ -65,7 +70,11 @@ function LiveProvider({
         };
 
         if (noInline) {
-          setState({ error: undefined, element: null }); // Reset output for async (no inline) evaluation
+          setState((previousState) => ({
+            ...previousState,
+            error: undefined,
+            element: null,
+          })); // Reset output for async (no inline) evaluation
           renderElementAsync(input, renderElement, errorCallback);
         } else {
           renderElement(generateElement(input, errorCallback));

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .js,.ts,.tsx src",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --config ./docusaurus.config.js --dir ./build/open-source/react-live --port 3565 --no-open",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

React-Live did not catch a runtime error (not caught in the transpile phase).

We can't catch all errors (like event handlers) but we can catch `useEffect`'s cleanup functions.

Fixes #388 

https://github.com/user-attachments/assets/7fa18a71-e688-406b-aa98-9f526518fa43

The above video demonstrates, not a cleanup function not causing crash.

Worth noting, cleanup function runs one cycle "behind", therefore even if we correct the code the previous code with error still shows up.

