### PR TITLE
feat: try to implement jsxRuntime option

### DIFF
--- a/packages/react-live/src/components/Live/LiveProvider.tsx
+++ b/packages/react-live/src/components/Live/LiveProvider.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState, ComponentType, PropsWithChildren } from "react";
 import LiveContext from "./LiveContext";
-import { generateElement, renderElementAsync } from "../../utils/transpile";
+import {
+  generateElement,
+  renderElementAsync,
+  type GenerateOptions,
+} from "../../utils/transpile";
 import { themes } from "prism-react-renderer";
 
 type ProviderState = {
@@ -13,6 +17,7 @@ type Props = {
   code?: string;
   disabled?: boolean;
   enableTypeScript?: boolean;
+  jsxRuntime?: GenerateOptions["jsxRuntime"];
   language?: string;
   noInline?: boolean;
   scope?: Record<string, unknown>;
@@ -26,6 +31,7 @@ function LiveProvider({
   language = "tsx",
   theme,
   enableTypeScript = true,
+  jsxRuntime,
   disabled = false,
   scope,
   transformCode,
@@ -67,6 +73,7 @@ function LiveProvider({
           code: transformedCode,
           scope,
           enableTypeScript,
+          jsxRuntime,
         };
 
         if (noInline) {

--- a/packages/react-live/src/utils/test/transpile.test.js
+++ b/packages/react-live/src/utils/test/transpile.test.js
@@ -12,6 +12,14 @@ describe("transpile", () => {
       expect(wrapper.html()).toBe(code);
     });
 
+    it("should transpile JSX - automatic runtime", () => {
+      const code = "<div>Hello World!</div>";
+      const Component = generateElement({ code, jsxRuntime: "automatic" });
+      const wrapper = shallow(<Component />);
+
+      expect(wrapper.html()).toBe(code);
+    });
+
     it("should transpile PFCs", () => {
       const code = "() => <div>Hello World!</div>";
       const Component = generateElement({ code });

--- a/packages/react-live/src/utils/transpile/transform.ts
+++ b/packages/react-live/src/utils/transpile/transform.ts
@@ -1,15 +1,26 @@
-import { transform as _transform, Transform } from "sucrase";
+import {
+  transform as _transform,
+  Transform,
+  Options as SucraseOptions,
+} from "sucrase";
 
 const defaultTransforms: Transform[] = ["jsx", "imports"];
 
 type Options = {
   transforms?: Transform[];
+  jsxRuntime?: SucraseOptions["jsxRuntime"];
 };
 
-export default function transform(opts: Options = {}) {
+function toSucraseOptions(opts: Options = {}): SucraseOptions {
   const transforms = Array.isArray(opts.transforms)
     ? opts.transforms.filter(Boolean)
     : defaultTransforms;
 
-  return (code: string) => _transform(code, { transforms }).code;
+  return { ...opts, transforms };
+}
+
+export default function transform(opts: Options = {}) {
+  const sucraseOptions = toSucraseOptions(opts);
+
+  return (code: string) => _transform(code, sucraseOptions).code;
 }


### PR DESCRIPTION


### Description

Attempt to add a new `jsxRuntime` option, forwarded to Sucrase

This gets rid of a new warning under React 19 in dev mode

Fixes https://github.com/FormidableLabs/react-live/issues/405


See also https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Unit tests

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
